### PR TITLE
readme: fix npm badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ a fork, create a pull request, we're always open to contributions :-)
 For larger changes/features, it's usually wise to open an issue before
 starting the work, so we can discuss if it's a fit.
 
-[npm-badge]: https://img.shields.io/npm/mirador-textoverlay.png?style=flat-square
+[npm-badge]: https://img.shields.io/npm/v/mirador-textoverlay.png?style=flat-square
 [npm]: https://www.npmjs.org/package/mirador-textoverlay
 
 [mirador-badge]: https://img.shields.io/badge/Mirador-%E2%89%A53.0.0--rc.3-blueviolet 


### PR DESCRIPTION
Hi,

the npm badge currently shows a 404 image:

![image](https://user-images.githubusercontent.com/20651387/87547493-76057d80-c6ab-11ea-89b8-d3257ea09b94.png)

This PR fixes the badge link and it now returns:

![image](https://user-images.githubusercontent.com/20651387/87547549-8d446b00-c6ab-11ea-8236-b95162d69b2d.png)
