### PR TITLE
Add 'fetching' indicator to tools bubble (#12)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -23,9 +23,6 @@
       }
     }],
     "react/prefer-stateless-function": "off",
-    "sort-keys": ["error", "asc", {
-      "caseSensitive": false,
-      "natural": false
-    }]
+    "sort-keys": "off",
   }
 }

--- a/__tests__/components/TextOverlaySettingsBubble.test.js
+++ b/__tests__/components/TextOverlaySettingsBubble.test.js
@@ -42,6 +42,7 @@ function renderBubble(props = {}) {
     imageToolsEnabled={false}
     t={(key) => key}
     textsAvailable
+    textsFetching={false}
     updateWindowTextOverlayOptions={updateOptionsMock}
     {...props}
     windowTextOverlayOptions={options}
@@ -188,5 +189,15 @@ describe('TextOverlaySettingsBubble', () => {
     renderBubble({ imageToolsEnabled: true });
     expect(screen.getByLabelText('expandTextOverlayOptions').parentElement)
       .toHaveStyle('top: 66px');
+  });
+
+  it('should be closed, disabled and surrounded by a progress bar when texts are fetching', () => {
+    renderBubble({ textsFetching: true, visible: true });
+    expect(screen.getByRole('progressbar')).toBeVisible();
+    expect(screen.getByLabelText('expandTextOverlayOptions')).toBeVisible();
+    expect(screen.getByLabelText('expandTextOverlayOptions')).toBeDisabled();
+    expect(screen.queryByLabelText('textSelect')).toBeNull();
+    expect(screen.queryByLabelText('textVisible')).toBeNull();
+    expect(screen.queryByLabelText('textOpacity')).toBeNull();
   });
 });

--- a/src/components/TextOverlaySettingsBubble.js
+++ b/src/components/TextOverlaySettingsBubble.js
@@ -6,11 +6,13 @@ import TextIcon from '@material-ui/icons/TextFields';
 import CloseIcon from '@material-ui/icons/Close';
 import SubjectIcon from '@material-ui/icons/Subject';
 import OpacityIcon from '@material-ui/icons/Opacity';
+import CircularProgress from '@material-ui/core/CircularProgress';
 import TextSelectIcon from './TextSelectIcon';
 
 /** Control text overlay settings  */
 const TextOverlaySettingsBubble = ({
-  windowTextOverlayOptions, imageToolsEnabled, textsAvailable, updateWindowTextOverlayOptions, t,
+  windowTextOverlayOptions, imageToolsEnabled, textsAvailable,
+  textsFetching, updateWindowTextOverlayOptions, t,
 }) => {
   const {
     enabled, visible, selectable, opacity,
@@ -35,7 +37,7 @@ const TextOverlaySettingsBubble = ({
         zIndex: 999,
       }}
     >
-      {open
+      {(open && !textsFetching)
       && (
       <>
         <div style={{
@@ -130,28 +132,29 @@ const TextOverlaySettingsBubble = ({
         </div>
       </>
       )}
+      {textsFetching
+        && <CircularProgress size={50} style={{ position: 'absolute' }} />}
       <MiradorMenuButton
         aria-label={open ? t('collapseTextOverlayOptions') : t('expandTextOverlayOptions')}
+        disabled={textsFetching}
         onClick={() => setOpen(!open)}
       >
-        { open ? <CloseIcon /> : <SubjectIcon />}
+        { (open && !textsFetching)
+          ? <CloseIcon />
+          : <SubjectIcon />}
       </MiradorMenuButton>
     </div>
   );
 };
 
 TextOverlaySettingsBubble.propTypes = {
-  imageToolsEnabled: PropTypes.bool,
-  t: PropTypes.func,
+  imageToolsEnabled: PropTypes.bool.isRequired,
+  t: PropTypes.func.isRequired,
   textsAvailable: PropTypes.bool.isRequired,
+  textsFetching: PropTypes.bool.isRequired,
   updateWindowTextOverlayOptions: PropTypes.func.isRequired,
   // eslint-disable-next-line react/forbid-prop-types
   windowTextOverlayOptions: PropTypes.object.isRequired,
-};
-
-TextOverlaySettingsBubble.defaultProps = {
-  imageToolsEnabled: false,
-  t: (key) => key,
 };
 
 export default TextOverlaySettingsBubble;

--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,7 @@ export default [
     mapStateToProps: (state, { windowId }) => ({
       imageToolsEnabled: getWindowConfig(state, { windowId }).imageToolsEnabled ?? false,
       textsAvailable: getTextsForVisibleCanvases(state, { windowId }).length > 0,
+      textsFetching: getTextsForVisibleCanvases(state, { windowId }).some((t) => t.isFetching),
       windowTextOverlayOptions: getWindowTextOverlayOptions(state, { windowId }),
     }),
     mode: 'add',


### PR DESCRIPTION
As outlined in #12, this adds a progress indicator to the tool bubble and keeps it disabled while fetching external OCR texts.

![indicator](https://user-images.githubusercontent.com/608610/87911314-afebd080-ca6b-11ea-916d-6a0d1c35bced.gif)
