### PR TITLE
Fix regressions from performance refactor, more tests

### DIFF
--- a/__fixtures__/lines.json
+++ b/__fixtures__/lines.json
@@ -1,0 +1,58 @@
+{
+  "withWords": [
+    {
+      "x": 50,
+      "y": 100,
+      "width": 1800,
+      "height": 120,
+      "words": [
+        { "text": "a", "x": 50, "y": 100, "width": 50, "height": 120 },
+        {
+          "text": "firstWord",
+          "x": 120,
+          "y": 100,
+          "width": 220,
+          "height": 120
+        },
+        { "text": "on", "x": 360, "y": 100, "width": 100, "height": 120 },
+        { "text": "a", "x": 480, "y": 100, "width": 50, "height": 120 },
+        { "text": "line", "x": 550, "y": 100, "width": 260, "height": 120 }
+      ]
+    },
+    {
+      "x": 50,
+      "y": 240,
+      "width": 1800,
+      "height": 120,
+      "words": [
+        { "text": "another", "x": 50, "y": 240, "width": 300, "height": 120 },
+        {
+          "text": "secondWord",
+          "x": 420,
+          "y": 240,
+          "width": 220,
+          "height": 120
+        },
+        { "text": "on", "x": 660, "y": 240, "width": 100, "height": 120 },
+        { "text": "another", "x": 780, "y": 240, "width": 300, "height": 120 },
+        { "text": "line", "x": 1150, "y": 240, "width": 260, "height": 120 }
+      ]
+    }
+  ],
+  "withoutWords": [
+    {
+      "x": 50,
+      "y": 100,
+      "width": 1800,
+      "height": 120,
+      "text": "a word on a line"
+    },
+    {
+      "x": 50,
+      "y": 240,
+      "width": 1800,
+      "height": 120,
+      "text": "another word on another line"
+    }
+  ]
+}

--- a/__tests__/components/PageTextDisplay.test.js
+++ b/__tests__/components/PageTextDisplay.test.js
@@ -1,0 +1,138 @@
+import React from 'react';
+
+import {
+  describe, it, jest, expect,
+} from '@jest/globals';
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+import PageTextDisplay from '../../src/components/PageTextDisplay';
+
+import lineFixtures from '../../__fixtures__/lines.json';
+
+
+/** Helper function to match against an elements inner text */
+function svgTextMatcher(text) {
+  return (content, element) => {
+    if (element.tagName === 'text') {
+      const elementText = Array.from(element.querySelectorAll('tspan'))
+        .map((el) => el.textContent).join(' ');
+      return elementText === text;
+    }
+    return false;
+  };
+}
+
+/** Render a page overlay to the testing screen */
+function renderPage(props = {}, renderFn = render) {
+  const pageRef = React.createRef();
+  const element = (
+    <PageTextDisplay
+      ref={pageRef}
+      selectable
+      visible
+      opacity={0.75}
+      width={2100}
+      height={2970}
+      source="http://example.com/page/1"
+      lines={lineFixtures.withWords}
+      {...props}
+    />
+  );
+  return { ...renderFn(element), ref: pageRef };
+}
+
+describe('PageTextDisplay', () => {
+  it('should render lines with individual words accurately', () => {
+    renderPage();
+    const firstLine = screen.getByText(svgTextMatcher('a firstWord on a line'));
+    expect(firstLine).not.toBeNull();
+    expect(firstLine.previousElementSibling).toHaveAttribute('style', 'fill: rgba(255, 255, 255, 0.75);');
+    expect(firstLine).toHaveAttribute('style', 'fill: rgba(0, 0, 0, 0.75);');
+    const word = screen.getByText('firstWord');
+    expect(word).not.toBeNull();
+    expect(word).toHaveAttribute('y', '190');
+    expect(word).toHaveAttribute('font-size', '120px');
+    expect(screen.getByText(svgTextMatcher('another secondWord on another line'))).not.toBeNull();
+  });
+
+  it('should render lines without individual words accurately', () => {
+    renderPage({ lines: lineFixtures.withoutWords });
+    const firstLine = screen.getByText('a word on a line');
+    expect(firstLine).not.toBeNull();
+    expect(firstLine.previousElementSibling).toHaveAttribute('style', 'fill: rgba(255, 255, 255, 0.75);');
+    expect(firstLine).toHaveAttribute('style', 'fill: rgba(0, 0, 0, 0.75);');
+    expect(firstLine).toHaveAttribute('y', '190');
+    expect(firstLine).toHaveAttribute('font-size', '120px');
+    expect(screen.getByText('another word on another line')).not.toBeNull();
+  });
+
+  it('should render invisible lines correctly', () => {
+    renderPage({ visible: false });
+    expect(screen.getByText(svgTextMatcher('a firstWord on a line')))
+      .toHaveAttribute('style', 'fill: rgba(0, 0, 0, 0);');
+    expect(screen.getByText(svgTextMatcher('another secondWord on another line')))
+      .toHaveAttribute('style', 'fill: rgba(0, 0, 0, 0);');
+  });
+
+  it('should not re-render by itself when the opacity changes', () => {
+    const { rerender } = renderPage();
+    expect(screen.getByText(svgTextMatcher('a firstWord on a line')))
+      .toHaveAttribute('style', 'fill: rgba(0, 0, 0, 0.75);');
+    renderPage({ opacity: 0.25 }, rerender);
+    expect(screen.getByText(svgTextMatcher('a firstWord on a line')))
+      .toHaveAttribute('style', 'fill: rgba(0, 0, 0, 0.75);');
+  });
+
+  it('should re-render when the source changes', () => {
+    const { rerender } = renderPage();
+    expect(screen.getByText(svgTextMatcher('a firstWord on a line'))).not.toBeNull();
+    renderPage({ source: 'http://example.com/pages/2', lines: lineFixtures.withoutWords, opacity: 0.25 }, rerender);
+    expect(screen.getByText('a word on a line'))
+      .toHaveAttribute('style', 'fill: rgba(0, 0, 0, 0.25);');
+  });
+
+  it('should correctly apply transformations to svg container', () => {
+    const { ref } = renderPage();
+    // FIXME: We should be able to use the container provided by RTL for this,
+    //        but its transform style remains empty after calling updateTransforms
+    //        for some mysterious reason :-/
+    const container = ref.current.containerRef.current;
+    expect(container.style.transform).toEqual('');
+    ref.current.updateTransforms(0.5, 200, 600);
+    expect(container.style.transform).toEqual('translate(-625px, -1042.5px) scale(0.5)');
+  });
+
+  it('should correctly set opacity to all rect and text elements', () => {
+    const { ref } = renderPage();
+    const firstLine = screen.getByText(svgTextMatcher('a firstWord on a line'));
+    expect(firstLine.previousElementSibling).toHaveAttribute('style', 'fill: rgba(255, 255, 255, 0.75);');
+    expect(firstLine).toHaveAttribute('style', 'fill: rgba(0, 0, 0, 0.75);');
+    ref.current.updateOpacity(0.25);
+    expect(firstLine.previousElementSibling).toHaveAttribute('style', 'fill: rgba(255, 255, 255, 0.25);');
+    expect(firstLine).toHaveAttribute('style', 'fill: rgba(0, 0, 0, 0.25);');
+  });
+
+  it('should render text invisible if visibility is disabled', () => {
+    const { rerender } = renderPage();
+    const firstLine = screen.getByText(svgTextMatcher('a firstWord on a line'));
+    expect(firstLine.previousElementSibling).toHaveAttribute('style', 'fill: rgba(255, 255, 255, 0.75);');
+    expect(firstLine).toHaveAttribute('style', 'fill: rgba(0, 0, 0, 0.75);');
+    renderPage({ visible: false }, rerender);
+    expect(firstLine.previousElementSibling).toHaveAttribute('style', 'fill: rgba(255, 255, 255, 0);');
+    expect(firstLine).toHaveAttribute('style', 'fill: rgba(0, 0, 0, 0);');
+  });
+
+  it('should prevent events from propagating to upper layers if selectability is enabled', () => {
+    const topCallback = jest.fn();
+    const { rerender, container } = renderPage({ selectable: false });
+    container.addEventListener('pointerdown', topCallback);
+    const firstLine = screen.getByText(svgTextMatcher('a firstWord on a line'));
+    fireEvent.pointerDown(firstLine);
+    expect(topCallback).toHaveBeenCalled();
+    topCallback.mockClear();
+    renderPage({ selectable: true }, rerender);
+    fireEvent.pointerDown(firstLine);
+    expect(topCallback).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/lib/ocrFormats.test.js
+++ b/__tests__/lib/ocrFormats.test.js
@@ -122,4 +122,10 @@ describe('parsing text from IIIF annotations', () => {
       y: 351,
     });
   });
+
+  it('should be able to infer a page size if none is passed', () => {
+    const parsed = parseIiifAnnotations(contentAsTextAnnos.resources);
+    expect(parsed.width).toEqual(2261);
+    expect(parsed.height).toEqual(3309);
+  });
 });

--- a/src/components/MiradorTextOverlay.js
+++ b/src/components/MiradorTextOverlay.js
@@ -120,25 +120,26 @@ class MiradorTextOverlay extends Component {
     return ReactDOM.createPortal(
       <>
         {pageTexts
-          .filter(({ lines }) => (
-            lines
-            && lines.length > 0
-            && lines.filter(({ text }) => text).length > 0))
           .map(({
             lines, source, width: pageWidth, height: pageHeight,
-          }, idx) => (
-            <PageTextDisplay
-              ref={this.renderRefs[idx]}
-              key={source}
-              lines={lines}
-              source={source}
-              selectable={selectable}
-              visible={visible}
-              opacity={opacity}
-              width={pageWidth}
-              height={pageHeight}
-            />
-          ))}
+          }, idx) => {
+            if (!this.shouldRenderPage({ lines })) {
+              return null;
+            }
+            return (
+              <PageTextDisplay
+                ref={this.renderRefs[idx]}
+                key={source}
+                lines={lines}
+                source={source}
+                selectable={selectable}
+                visible={visible}
+                opacity={opacity}
+                width={pageWidth}
+                height={pageHeight}
+              />
+            );
+          })}
       </>,
       viewer.canvas,
     );

--- a/src/components/MiradorTextOverlay.js
+++ b/src/components/MiradorTextOverlay.js
@@ -41,8 +41,8 @@ class MiradorTextOverlay extends Component {
     // Newly enabled, force initial setting of state from OSD
     const newlyEnabled = (
       (this.shouldRender() && !this.shouldRender(prevProps))
-      || (pageTexts.filter(({ lines }) => lines.length > 0).length
-          !== prevProps.pageTexts.filter(({ lines }) => lines.length > 0).length));
+      || (pageTexts.filter(this.shouldRenderPage).length
+          !== prevProps.pageTexts.filter(this.shouldRenderPage).length));
 
     if (newlyEnabled) {
       this.onUpdateViewport();
@@ -89,6 +89,12 @@ class MiradorTextOverlay extends Component {
     }
   }
 
+  /** If the page should be rendered */
+  shouldRenderPage = ({ lines }) => (
+    lines
+    && lines.length > 0
+    && lines.some(({ text, words }) => text || (words && words.length > 0)))
+
   /** If the overlay should be rendered at all */
   shouldRender(props) {
     const {
@@ -114,7 +120,10 @@ class MiradorTextOverlay extends Component {
     return ReactDOM.createPortal(
       <>
         {pageTexts
-          .filter(({ lines }) => lines && lines.length > 0)
+          .filter(({ lines }) => (
+            lines
+            && lines.length > 0
+            && lines.filter(({ text }) => text).length > 0))
           .map(({
             lines, source, width: pageWidth, height: pageHeight,
           }, idx) => (

--- a/src/components/PageTextDisplay.js
+++ b/src/components/PageTextDisplay.js
@@ -65,6 +65,7 @@ class PageTextDisplay extends React.Component {
       `translate(${translateX}px, ${translateY}px)`,
       `scale(${scaleFactor})`,
     ];
+    this.containerRef.current.style.display = null;
     this.containerRef.current.style.transform = containerTransforms.join(' ');
   }
 
@@ -98,6 +99,7 @@ class PageTextDisplay extends React.Component {
       // (without using translate3d) and achieve 60fps on a regular laptop even with huge objects.
       willChange: 'transform',
       position: 'absolute',
+      display: 'none', // will be cleared by first update
     };
     const svgStyle = {
       width: pageWidth,

--- a/src/components/PageTextDisplay.js
+++ b/src/components/PageTextDisplay.js
@@ -23,7 +23,7 @@ class PageTextDisplay extends React.Component {
   /** Register pointerdown handler on SVG container */
   componentDidMount() {
     // FIXME: We should be able to use React for this, but it somehow doesn't work
-    this.svgContainerRef.current.onpointerdown = this.onPointerDown;
+    this.svgContainerRef.current.addEventListener('pointerdown', this.onPointerDown);
   }
 
   /** Only update the component when some of the props changed.

--- a/src/lib/ocrFormats.js
+++ b/src/lib/ocrFormats.js
@@ -1,3 +1,5 @@
+import max from 'lodash/max';
+
 /** Functions to parse OCR boxes from various formats and render them as SVG. */
 const parser = new DOMParser();
 const namespaces = {
@@ -238,8 +240,8 @@ export function parseAlto(altoText, imgSize) {
 /** Helper to calculate a rough fallback image size from the line coordinates */
 function getFallbackImageSize(lines) {
   return {
-    width: Math.max.apply(null, lines.map(({ x, width }) => x + width)),
-    height: Math.max.apply(null, lines.map(({ y, height }) => y + height)),
+    width: max(lines.map(({ x, width }) => x + width)),
+    height: max(lines.map(({ y, height }) => y + height)),
   };
 }
 


### PR DESCRIPTION
- **Don't render page text overlay when none of the lines have text.**
  This fixes a bug with lazily loaded annotation texts in combination with the recent performance optimizations that resulted in text not being rendered.
-  **Don't show text until first transformation has been applied**
   This prevents glitchy text display during page changes where there would be unscaled OCR text filling the screen for a few frames.
-  **Make sure the text parse always includes page dimensions.**
   With the recent performance work, it has become mandatory that text parses contain their page's width and height. This commit adds a new source for those values in ALTO documents and adds a generic fallback heuristic to determine a rough page size from the coordinates of the text lines on the page.
- **Fix bug when left page in book view didn't have text**

Also unifies OCR parsing to use `querySelector` instead of XPath for both hOCR and ALTO, as well as a rudimentary test suite for the `PageTextDisplay` component.