### PR TITLE
Improve word rendering

### DIFF
--- a/src/components/PageTextDisplay.js
+++ b/src/components/PageTextDisplay.js
@@ -132,9 +132,9 @@ class PageTextDisplay extends React.Component {
                         <tspan
                           key={`${lineIdx}-${wordIdx}`}
                           x={x}
-                          y={y + height * 0.75}
+                          y={line.y + line.height * 0.75}
                           textLength={width}
-                          fontSize={`${height}px`}
+                          fontSize={`${line.height}px`}
                           lengthAdjust="spacingAndGlyphs"
                         >
                           {text}


### PR DESCRIPTION
Previously we'd use a word's Y-Position and its height as the font-size in pixels. This led to a very irregular line appearance, since words consisting of all-lowercase letters would be rendered far too small.
![before_close](https://user-images.githubusercontent.com/608610/88272075-6e139200-ccd8-11ea-8913-3848b4c3f5de.png)

With this change, we now use the line's Y-position and height instead, making for a far more regular line appearance, with no problems for selecting text.
![after_close_000](https://user-images.githubusercontent.com/608610/88272137-87b4d980-ccd8-11ea-958a-09026f7a9a92.png)
