### PR TITLE
Improve handling of spaces, test selection

### DIFF
--- a/__fixtures__/lines.json
+++ b/__fixtures__/lines.json
@@ -8,15 +8,15 @@
       "words": [
         { "text": "a", "x": 50, "y": 100, "width": 50, "height": 120 },
         {
-          "text": "firstWord",
+          "text": "firstWord ",
           "x": 120,
           "y": 100,
           "width": 220,
           "height": 120
         },
-        { "text": "on", "x": 360, "y": 100, "width": 100, "height": 120 },
-        { "text": "a", "x": 480, "y": 100, "width": 50, "height": 120 },
-        { "text": "line", "x": 550, "y": 100, "width": 260, "height": 120 }
+        { "text": "on ", "x": 360, "y": 100, "width": 100, "height": 120 },
+        { "text": "a ", "x": 480, "y": 100, "width": 50, "height": 120 },
+        { "text": "line\n", "x": 550, "y": 100, "width": 260, "height": 120 }
       ]
     },
     {
@@ -25,17 +25,17 @@
       "width": 1800,
       "height": 120,
       "words": [
-        { "text": "another", "x": 50, "y": 240, "width": 300, "height": 120 },
+        { "text": "another ", "x": 50, "y": 240, "width": 300, "height": 120 },
         {
-          "text": "secondWord",
+          "text": "secondWord ",
           "x": 420,
           "y": 240,
           "width": 220,
           "height": 120
         },
-        { "text": "on", "x": 660, "y": 240, "width": 100, "height": 120 },
-        { "text": "another", "x": 780, "y": 240, "width": 300, "height": 120 },
-        { "text": "line", "x": 1150, "y": 240, "width": 260, "height": 120 }
+        { "text": "on ", "x": 660, "y": 240, "width": 100, "height": 120 },
+        { "text": "another ", "x": 780, "y": 240, "width": 300, "height": 120 },
+        { "text": "line\n", "x": 1150, "y": 240, "width": 260, "height": 120 }
       ]
     }
   ],

--- a/__tests__/components/PageTextDisplay.test.js
+++ b/__tests__/components/PageTextDisplay.test.js
@@ -16,8 +16,8 @@ function svgTextMatcher(text) {
   return (content, element) => {
     if (element.tagName === 'text') {
       const elementText = Array.from(element.querySelectorAll('tspan'))
-        .map((el) => el.textContent).join(' ');
-      return elementText === text;
+        .map((el) => el.textContent.trim()).join(' ');
+      return elementText.startsWith(text);
     }
     return false;
   };
@@ -134,5 +134,17 @@ describe('PageTextDisplay', () => {
     renderPage({ selectable: true }, rerender);
     fireEvent.pointerDown(firstLine);
     expect(topCallback).not.toHaveBeenCalled();
+  });
+
+  it('should include whitespace and linebreaks when selecting text from overlay', () => {
+    renderPage();
+    const range = new Range();
+    const startNode = screen.getByText('firstWord');
+    range.setStart(startNode, 0);
+    const endNode = screen.getByText('secondWord');
+    range.setEnd(endNode.nextElementSibling, 0);
+    document.getSelection().addRange(range);
+    expect(document.getSelection().toString())
+      .toEqual('firstWord on a line\nanother secondWord ');
   });
 });

--- a/__tests__/lib/ocrFormats.test.js
+++ b/__tests__/lib/ocrFormats.test.js
@@ -38,23 +38,23 @@ describe('parsing ALTO', () => {
       x: closeTo(82.28),
       y: closeTo(1236.09),
     });
-    expect(parsed.lines[54].words).toHaveLength(9);
-    expect(parsed.lines[64].words[6]).toMatchObject({
+    expect(parsed.lines[54].words).toHaveLength(5);
+    expect(parsed.lines[64].words[3]).toMatchObject({
       height: closeTo(10.23),
-      text: 'mission',
-      width: closeTo(42.91),
+      text: 'mission ',
+      width: closeTo(49.04),
       x: closeTo(189.36),
       y: closeTo(1237.27),
     });
   });
 
   it('should not add newlines at the end of hyphenated lines', () => {
-    expect(parsed.lines[94].words[10].text).toMatch('exa');
-    expect(parsed.lines[96].words[16].text).toMatch('Débats\n');
+    expect(parsed.lines[94].words[5].text).toMatch('exa');
+    expect(parsed.lines[96].words[8].text).toMatch('Débats\n');
   });
 
   it('should convert style nodes to proper CSS', () => {
-    expect(parsed.lines[96].words[16].style)
+    expect(parsed.lines[96].words[8].style)
       .toBe('font-family: Times New Roman;font-style: italic');
   });
 });

--- a/__tests__/lib/ocrFormats.test.js
+++ b/__tests__/lib/ocrFormats.test.js
@@ -42,7 +42,7 @@ describe('parsing ALTO', () => {
     expect(parsed.lines[64].words[3]).toMatchObject({
       height: closeTo(10.23),
       text: 'mission ',
-      width: closeTo(49.04),
+      width: closeTo(42.91),
       x: closeTo(189.36),
       y: closeTo(1237.27),
     });
@@ -81,7 +81,7 @@ describe('parsing hOCR', () => {
     expect(parsed.lines[29].words[7]).toMatchObject({
       height: 56,
       text: '„aber ',
-      width: 142.8,
+      width: 119,
       x: 922,
       y: 2097,
     });

--- a/src/components/PageTextDisplay.js
+++ b/src/components/PageTextDisplay.js
@@ -146,7 +146,6 @@ class PageTextDisplay extends React.Component {
                         {text}
                       </tspan>
                     ))}
-                    )
                   </text>
                 )
                 : (

--- a/src/lib/ocrFormats.js
+++ b/src/lib/ocrFormats.js
@@ -39,7 +39,7 @@ function parseHocrNode(node, endOfLine = false, scaleFactor = 1) {
     text += extraText;
     // Increase the width of the node to compensate for the extra characters
     if (!endOfLine) {
-      width += charWidth * extraText.length;
+      width += charWidth * extraText.trim().length;
     }
   }
   let style = node.getAttribute('style');
@@ -74,8 +74,6 @@ export function parseHocr(hocrText, referenceSize) {
     scaleFactor = scaleFactorX;
   }
   const lines = [];
-  // FIXME: Seems to be an eslint bug: https://github.com/eslint/eslint/issues/12117
-  // eslint-disable-next-line no-unused-vars
   for (const lineNode of pageNode.querySelectorAll(
     'span.ocr_line, span.ocrx_line',
   )) {
@@ -205,7 +203,7 @@ export function parseAlto(altoText, imgSize) {
         lineEndsHyphenated = true;
       }
       // NOTE: Hyphenation elements are ignored
-      let width = Number.parseInt(wordNode.getAttribute('WIDTH'), 10) * scaleFactorX;
+      const width = Number.parseInt(wordNode.getAttribute('WIDTH'), 10) * scaleFactorX;
       const height = Number.parseInt(wordNode.getAttribute('HEIGHT'), 10) * scaleFactorY;
       const x = Number.parseInt(wordNode.getAttribute('HPOS'), 10) * scaleFactorX;
       const y = Number.parseInt(wordNode.getAttribute('VPOS'), 10) * scaleFactorY;
@@ -218,7 +216,6 @@ export function parseAlto(altoText, imgSize) {
         || (sibling && sibling.tagName === 'SP')
       );
       if (addSpace) {
-        width += width / text.length;
         text += ' ';
       }
       if (text) {

--- a/src/lib/ocrFormats.js
+++ b/src/lib/ocrFormats.js
@@ -187,7 +187,7 @@ export function parseAlto(altoText, imgSize) {
       x: Number.parseInt(lineNode.getAttribute('HPOS'), 10) * scaleFactorX,
       y: Number.parseInt(lineNode.getAttribute('VPOS'), 10) * scaleFactorY,
     };
-    const wordElems = lineNode.querySelectorAll('String, SP, HYP');
+    const wordElems = lineNode.querySelectorAll('String, HYP');
     for (const wordNode of wordElems) {
       const styleRefs = wordNode.getAttribute('STYLEREFS');
       let style = null;
@@ -201,8 +201,6 @@ export function parseAlto(altoText, imgSize) {
       let text;
       if (wordNode.tagName === 'String') {
         text = wordNode.getAttribute('CONTENT');
-      } else if (wordNode.tagName === 'SP') {
-        text = ' ';
       } else if (wordNode.tagName === 'HYP') {
         lineEndsHyphenated = true;
       }
@@ -212,8 +210,14 @@ export function parseAlto(altoText, imgSize) {
       const x = Number.parseInt(wordNode.getAttribute('HPOS'), 10) * scaleFactorX;
       const y = Number.parseInt(wordNode.getAttribute('VPOS'), 10) * scaleFactorY;
 
-      // Not at end of line and doc doesn't encode spaces, add whitespace after word
-      if (!hasSpaces && text !== ' ' && wordNode) {
+      const sibling = wordNode.nextElementSibling;
+      const addSpace = (
+        // Doc doesn't encode spaces, add whitespace after word
+        (!hasSpaces && text !== ' ' && wordNode)
+        // Check if next sibling is a space element
+        || (sibling && sibling.tagName === 'SP')
+      );
+      if (addSpace) {
         width += width / text.length;
         text += ' ';
       }
@@ -225,6 +229,7 @@ export function parseAlto(altoText, imgSize) {
       line.text += text;
     }
     if (!lineEndsHyphenated) {
+      // Strip last space from line, replace with newline
       line.words.slice(-1)[0].text += '\n';
     }
     lineEndsHyphenated = false;


### PR DESCRIPTION
Previously our approach to parsing spaces would differ between ALTO and hOCR. In the former, we'd have empty word objects, in the latter the whitespace would be included in the text of its previous word. This has now been unified to always be part of the previous word.

Additonally, we no longer consider whitespace when expanding the word width to include extra characters, this results in a much closer match between text and image and better selection precision.

Also included now is a test for the selection functionality.