### PR TITLE
Auto-select text and background colors, add color picker widget

### DIFF
--- a/__tests__/components/PageTextDisplay.test.js
+++ b/__tests__/components/PageTextDisplay.test.js
@@ -38,6 +38,8 @@ function renderPage(props = {}, renderFn = render) {
       height={2970}
       source="http://example.com/page/1"
       lines={lineFixtures.withWords}
+      bgColor="#ffffff"
+      textColor="#000000"
       {...props}
     />
   );

--- a/__tests__/components/PageTextDisplay.test.js
+++ b/__tests__/components/PageTextDisplay.test.js
@@ -40,6 +40,7 @@ function renderPage(props = {}, renderFn = render) {
       lines={lineFixtures.withWords}
       bgColor="#ffffff"
       textColor="#000000"
+      useAutoColors={false}
       {...props}
     />
   );
@@ -160,5 +161,20 @@ describe('PageTextDisplay', () => {
     global.navigator.userAgent = prevAgent;
     const word = screen.getByText('firstWord');
     expect(word).toHaveAttribute('textLength', '198');
+  });
+
+  it('should use automatically determined colors for the initial render if available and enabled', () => {
+    const pageColors = { textColor: '#111111', bgColor: '#eeeeee' };
+    renderPage({ useAutoColors: true, pageColors });
+    const firstLine = screen.getByText(svgTextMatcher('a firstWord on a line'));
+    expect(firstLine).toHaveAttribute('style', 'fill: rgba(17, 17, 17, 0.75);');
+    expect(firstLine.previousElementSibling).toHaveAttribute('style', 'fill: rgba(238, 238, 238, 0.75);');
+  });
+
+  it('should use hardcoded colors for the initial render if enabled, but not available', () => {
+    renderPage({ useAutoColors: true, pageColors: undefined });
+    const firstLine = screen.getByText(svgTextMatcher('a firstWord on a line'));
+    expect(firstLine).toHaveAttribute('style', 'fill: rgba(0, 0, 0, 0.75);');
+    expect(firstLine.previousElementSibling).toHaveAttribute('style', 'fill: rgba(255, 255, 255, 0.75);');
   });
 });

--- a/__tests__/components/PageTextDisplay.test.js
+++ b/__tests__/components/PageTextDisplay.test.js
@@ -114,7 +114,7 @@ describe('PageTextDisplay', () => {
     const firstLine = screen.getByText(svgTextMatcher('a firstWord on a line'));
     expect(firstLine.previousElementSibling).toHaveAttribute('style', 'fill: rgba(255, 255, 255, 0.75);');
     expect(firstLine).toHaveAttribute('style', 'fill: rgba(0, 0, 0, 0.75);');
-    ref.current.updateOpacity(0.25);
+    ref.current.updateColors('#000000', '#ffffff', 0.25);
     expect(firstLine.previousElementSibling).toHaveAttribute('style', 'fill: rgba(255, 255, 255, 0.25);');
     expect(firstLine).toHaveAttribute('style', 'fill: rgba(0, 0, 0, 0.25);');
   });

--- a/__tests__/components/TextOverlaySettingsBubble.test.js
+++ b/__tests__/components/TextOverlaySettingsBubble.test.js
@@ -246,7 +246,7 @@ describe('TextOverlaySettingsBubble', () => {
     expect(bgInput).toHaveValue('#444444');
   });
 
-  it('should not render the auto-color button if no page colors are available', () => {
+  it('should not render the reset button if no page colors are available', () => {
     renderBubble({
       windowTextOverlayOptions: { visible: true },
       pageColors: [undefined, undefined],

--- a/__tests__/lib/color.js
+++ b/__tests__/lib/color.js
@@ -1,0 +1,32 @@
+import { changeAlpha, toHexRgb } from '../../src/lib/color';
+
+describe('changeAlpha', () => {
+  it('Should work with 6-digit hex colors', () => {
+    expect(changeAlpha('#ffffff', 0.5)).toEqual('rgba(255, 255, 255, 0.5)');
+  });
+  it('Should work with 3-digit hex colors', () => {
+    expect(changeAlpha('#abc', 0.5)).toEqual('rgba(170, 187, 204, 0.5)');
+  });
+  it('Should work with rbga colors', () => {
+    expect(changeAlpha('rgba(123, 221, 100, 0.1)', 0.5)).toEqual('rgba(123, 221, 100,0.5)');
+  });
+  it('Should work with rgb colors', () => {
+    expect(changeAlpha('rgb(123, 221, 100)', 0.5)).toEqual('rgba(123, 221, 100, 0.5)');
+  });
+  it('Should return unsupported colors unmodified', () => {
+    const origError = console.error;
+    console.error = jest.fn();
+    expect(changeAlpha('hsv(210, 17, 80)', 0.5)).toEqual('hsv(210, 17, 80)');
+    expect(console.error).toHaveBeenCalledWith('Unsupported color: hsv(210, 17, 80)');
+    console.error = origError;
+  });
+});
+
+describe('toHexRgb', () => {
+  it('Should work with rgb strings', () => {
+    expect(toHexRgb('rgb(170, 187, 204)')).toEqual('#aabbcc');
+  });
+  it('Should work with rgba strings', () => {
+    expect(toHexRgb('rgb(170, 187, 204, 0.75)')).toEqual('#aabbcc');
+  });
+});

--- a/__tests__/lib/color.test.js
+++ b/__tests__/lib/color.test.js
@@ -1,4 +1,4 @@
-import { changeAlpha, toHexRgb } from '../../src/lib/color';
+import { changeAlpha, toHexRgb, getPageColors } from '../../src/lib/color';
 
 describe('changeAlpha', () => {
   it('Should work with 6-digit hex colors', () => {
@@ -28,5 +28,17 @@ describe('toHexRgb', () => {
   });
   it('Should work with rgba strings', () => {
     expect(toHexRgb('rgb(170, 187, 204, 0.75)')).toEqual('#aabbcc');
+  });
+});
+
+describe('getPageColors', () => {
+  // NOTE: We should really test with actual images here, but unfortunately our current algorithm
+  //       relies on the way Gecko and WebKit render images, which seems to drastically differ from
+  //       the way the Cairo canvas that we have available in the test env renders them ¯\_(ツ)_/¯
+  it('should be able to determine foreground and background from 4-pixel mock image', () => {
+    const mockData = [255, 255, 255, 255, 0, 0, 0, 255, 0, 0, 0, 255, 0, 0, 0, 255];
+    const { textColor, bgColor } = getPageColors(mockData);
+    expect(textColor).toEqual('rgb(0,0,0)');
+    expect(bgColor).toEqual('rgb(255,255,255)');
   });
 });

--- a/__tests__/state/sagas.test.js
+++ b/__tests__/state/sagas.test.js
@@ -340,14 +340,15 @@ describe('Reacting to configuration changes', () => {
 describe('Fetching page colors', () => {
   const targetId = 'canvasA';
   const infoId = 'http://example.com/iiif/image/canvasA';
+  const colors = { textColor: '#abcdef', bgColor: '#fedcba' };
   it('should immediately trigger a fetch if info response is available',
     () => expectSaga(fetchColors, { targetId, infoId })
       .provide([
         [select(selectInfoResponse, { infoId }), { id: infoId }],
         [call(loadImageData, `${infoId}/full/200,/0/default.jpg`), 'data'],
-        [call(getPageColors, 'data'), { textColor: '#abcdef', bgColor: '#fedcba' }],
+        [call(getPageColors, 'data'), colors],
       ])
-      .put(receiveColors(targetId, '#abcdef', '#fedcba'))
+      .put(receiveColors(targetId, colors.textColor, colors.bgColor))
       .run());
 
   it('should wait for info response reception if it is initially unavailable',
@@ -355,14 +356,14 @@ describe('Fetching page colors', () => {
       .provide([
         [select(selectInfoResponse, { infoId }), undefined],
         [call(loadImageData, `${infoId}/full/200,/0/default.jpg`), 'data'],
-        [call(getPageColors, 'data'), { textColor: '#abcdef', bgColor: '#fedcba' }],
+        [call(getPageColors, 'data'), colors],
       ])
       .dispatch({
         type: ActionTypes.RECEIVE_INFO_RESPONSE,
         infoId,
         infoJson: { '@id': infoId },
       })
-      .put(receiveColors(targetId, '#abcdef', '#fedcba'))
+      .put(receiveColors(targetId, colors.textColor, colors.bgColor))
       .run());
 
   it('should not do anything if the info response reception has failed',

--- a/__tests__/state/sagas.test.js
+++ b/__tests__/state/sagas.test.js
@@ -15,10 +15,11 @@ import {
   discoverExternalOcr, fetchAndProcessOcr, fetchOcrMarkup,
   fetchExternalAnnotationResources, fetchAnnotationResource,
   processTextsFromAnnotations, onConfigChange, fetchColors,
+  loadImageData,
 } from '../../src/state/sagas';
 import { getTexts, getTextsForVisibleCanvases } from '../../src/state/selectors';
 import { parseOcr, parseIiifAnnotations } from '../../src/lib/ocrFormats';
-import { getLineColors } from '../../src/lib/color';
+import { getPageColors } from '../../src/lib/color';
 
 const canvasSize = {
   height: 1000,
@@ -343,7 +344,8 @@ describe('Fetching page colors', () => {
     () => expectSaga(fetchColors, { targetId, infoId })
       .provide([
         [select(selectInfoResponse, { infoId }), { id: infoId }],
-        [call(getLineColors, infoId), { textColor: '#abcdef', bgColor: '#fedcba' }],
+        [call(loadImageData, `${infoId}/full/200,/0/default.jpg`), 'data'],
+        [call(getPageColors, 'data'), { textColor: '#abcdef', bgColor: '#fedcba' }],
       ])
       .put(receiveColors(targetId, '#abcdef', '#fedcba'))
       .run());
@@ -352,7 +354,8 @@ describe('Fetching page colors', () => {
     () => expectSaga(fetchColors, { targetId, infoId })
       .provide([
         [select(selectInfoResponse, { infoId }), undefined],
-        [call(getLineColors, infoId), { textColor: '#abcdef', bgColor: '#fedcba' }],
+        [call(loadImageData, `${infoId}/full/200,/0/default.jpg`), 'data'],
+        [call(getPageColors, 'data'), { textColor: '#abcdef', bgColor: '#fedcba' }],
       ])
       .dispatch({
         type: ActionTypes.RECEIVE_INFO_RESPONSE,

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@material-ui/icons": "^4.9.1",
     "isomorphic-unfetch": "^3.0.0",
     "lodash": "^4.17.11",
+    "manifesto.js": "^4.1.0",
     "mirador": "^3.0.0-rc.4",
     "prop-types": "^15.7.2",
     "react": "16.x",

--- a/src/components/MiradorTextOverlay.js
+++ b/src/components/MiradorTextOverlay.js
@@ -31,7 +31,7 @@ class MiradorTextOverlay extends Component {
   /** Register OpenSeadragon callback when viewport changes */
   componentDidUpdate(prevProps) {
     const {
-      enabled, viewer, opacity, pageTexts,
+      enabled, viewer, opacity, pageTexts, textColor, bgColor,
     } = this.props;
 
     // OSD instance becomes available, register callback
@@ -48,11 +48,13 @@ class MiradorTextOverlay extends Component {
       this.onUpdateViewport();
     }
 
-    // Manually update SVG opacity for performance reasons
-    if (opacity !== prevProps.opacity) {
+    // Manually update SVG colors for performance reasons
+    if (opacity !== prevProps.opacity
+        || bgColor !== prevProps.bgColor
+        || textColor !== prevProps.textColor) {
       this.renderRefs
         .filter((ref) => ref.current != null)
-        .forEach((ref) => ref.current.updateOpacity(opacity));
+        .forEach((ref) => ref.current.updateColors(textColor, bgColor, opacity));
     }
   }
 

--- a/src/components/MiradorTextOverlay.js
+++ b/src/components/MiradorTextOverlay.js
@@ -112,7 +112,7 @@ class MiradorTextOverlay extends Component {
   /** Render the text overlay SVG */
   render() {
     const {
-      pageTexts, selectable, visible, viewer, opacity,
+      pageTexts, selectable, visible, viewer, opacity, textColor, bgColor,
     } = this.props;
     if (!this.shouldRender() || !viewer || !pageTexts) {
       return null;
@@ -137,6 +137,8 @@ class MiradorTextOverlay extends Component {
                 opacity={opacity}
                 width={pageWidth}
                 height={pageHeight}
+                textColor={textColor}
+                bgColor={bgColor}
               />
             );
           })}
@@ -154,6 +156,8 @@ MiradorTextOverlay.propTypes = {
   selectable: PropTypes.bool,
   viewer: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   visible: PropTypes.bool,
+  textColor: PropTypes.string,
+  bgColor: PropTypes.string,
 };
 
 MiradorTextOverlay.defaultProps = {
@@ -164,6 +168,8 @@ MiradorTextOverlay.defaultProps = {
   selectable: true,
   viewer: undefined,
   visible: false,
+  textColor: '#000000',
+  bgColor: '#ffffff',
 };
 
 export default MiradorTextOverlay;

--- a/src/components/PageTextDisplay.js
+++ b/src/components/PageTextDisplay.js
@@ -98,6 +98,7 @@ class PageTextDisplay extends React.Component {
   render() {
     const {
       selectable, visible, lines, width: pageWidth, height: pageHeight, opacity, textColor, bgColor,
+      useAutoColors, pageColors,
     } = this.props;
 
     const containerStyle = {
@@ -112,9 +113,16 @@ class PageTextDisplay extends React.Component {
       height: pageHeight,
       cursor: selectable ? undefined : 'default',
     };
+    let fg = textColor;
+    let bg = bgColor;
+    if (useAutoColors && pageColors) {
+      fg = pageColors.textColor;
+      bg = pageColors.bgColor;
+    }
+
     const renderOpacity = (!visible && selectable) ? 0 : opacity;
-    const boxStyle = { fill: changeAlpha(bgColor, renderOpacity) };
-    const textStyle = { fill: changeAlpha(textColor, renderOpacity) };
+    const boxStyle = { fill: changeAlpha(bg, renderOpacity) };
+    const textStyle = { fill: changeAlpha(fg, renderOpacity) };
     const renderLines = lines.filter((l) => l.width > 0 && l.height > 0);
 
     /* Firefox/Gecko does not currently support the lengthAdjust parameter on
@@ -209,11 +217,17 @@ PageTextDisplay.propTypes = {
   opacity: PropTypes.number.isRequired,
   textColor: PropTypes.string.isRequired,
   bgColor: PropTypes.string.isRequired,
+  useAutoColors: PropTypes.bool.isRequired,
   width: PropTypes.number.isRequired,
   height: PropTypes.number.isRequired,
   // eslint-disable-next-line react/forbid-prop-types
   lines: PropTypes.array.isRequired,
   source: PropTypes.string.isRequired,
+  // eslint-disable-next-line react/forbid-prop-types
+  pageColors: PropTypes.object,
+};
+PageTextDisplay.defaultProps = {
+  pageColors: undefined,
 };
 
 export default PageTextDisplay;

--- a/src/components/PageTextDisplay.js
+++ b/src/components/PageTextDisplay.js
@@ -39,15 +39,11 @@ class PageTextDisplay extends React.Component {
    * but this way we can more precisely control when we re-render.
    */
   shouldComponentUpdate(nextProps) {
-    const {
-      source, selectable, visible, textColor, bgColor,
-    } = this.props;
+    const { source, selectable, visible } = this.props;
     return (
       nextProps.source !== source
       || nextProps.selectable !== selectable
       || nextProps.visible !== visible
-      || nextProps.textColor !== textColor
-      || nextProps.bgColor !== bgColor
     );
   }
 
@@ -83,14 +79,13 @@ class PageTextDisplay extends React.Component {
    *
    * Again, intended to be called from the parent, again for performance reasons.
    */
-  updateOpacity(opacity) {
+  updateColors(textColor, bgColor, opacity) {
     if (!this.svgContainerRef.current) {
       return;
     }
-    // We need to apply the opacity to the individual rects and texts instead of
+    // We need to apply the colors to the individual rects and texts instead of
     // one of the containers, since otherwise the user's selection highlight would
     // become transparent as well or disappear entirely.
-    const { bgColor, textColor } = this.props;
     for (const rect of this.svgContainerRef.current.querySelectorAll('rect')) {
       rect.style.fill = changeAlpha(bgColor, opacity);
     }

--- a/src/components/PageTextDisplay.js
+++ b/src/components/PageTextDisplay.js
@@ -4,6 +4,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { changeAlpha } from '../lib/color';
+
 /** Check if we're running in Gecko */
 function runningInGecko() {
   return navigator.userAgent.indexOf('Gecko/') >= 0;
@@ -37,11 +39,15 @@ class PageTextDisplay extends React.Component {
    * but this way we can more precisely control when we re-render.
    */
   shouldComponentUpdate(nextProps) {
-    const { source, selectable, visible } = this.props;
+    const {
+      source, selectable, visible, textColor, bgColor,
+    } = this.props;
     return (
       nextProps.source !== source
       || nextProps.selectable !== selectable
       || nextProps.visible !== visible
+      || nextProps.textColor !== textColor
+      || nextProps.bgColor !== bgColor
     );
   }
 
@@ -84,18 +90,19 @@ class PageTextDisplay extends React.Component {
     // We need to apply the opacity to the individual rects and texts instead of
     // one of the containers, since otherwise the user's selection highlight would
     // become transparent as well or disappear entirely.
+    const { bgColor, textColor } = this.props;
     for (const rect of this.svgContainerRef.current.querySelectorAll('rect')) {
-      rect.style.fill = `rgba(255, 255, 255, ${opacity})`;
+      rect.style.fill = changeAlpha(bgColor, opacity);
     }
     for (const text of this.svgContainerRef.current.querySelectorAll('text')) {
-      text.style.fill = `rgba(0, 0, 0, ${opacity})`;
+      text.style.fill = changeAlpha(textColor, opacity);
     }
   }
 
   /** Render the page overlay */
   render() {
     const {
-      selectable, visible, lines, width: pageWidth, height: pageHeight, opacity,
+      selectable, visible, lines, width: pageWidth, height: pageHeight, opacity, textColor, bgColor,
     } = this.props;
 
     const containerStyle = {
@@ -111,8 +118,8 @@ class PageTextDisplay extends React.Component {
       cursor: selectable ? undefined : 'default',
     };
     const renderOpacity = (!visible && selectable) ? 0 : opacity;
-    const boxStyle = { fill: `rgba(255, 255, 255, ${renderOpacity})` };
-    const textStyle = { fill: `rgba(0, 0, 0, ${renderOpacity})` };
+    const boxStyle = { fill: changeAlpha(bgColor, renderOpacity) };
+    const textStyle = { fill: changeAlpha(textColor, renderOpacity) };
     const renderLines = lines.filter((l) => l.width > 0 && l.height > 0);
 
     /* Firefox/Gecko does not currently support the lengthAdjust parameter on
@@ -205,6 +212,8 @@ PageTextDisplay.propTypes = {
   selectable: PropTypes.bool.isRequired,
   visible: PropTypes.bool.isRequired,
   opacity: PropTypes.number.isRequired,
+  textColor: PropTypes.string.isRequired,
+  bgColor: PropTypes.string.isRequired,
   width: PropTypes.number.isRequired,
   height: PropTypes.number.isRequired,
   // eslint-disable-next-line react/forbid-prop-types

--- a/src/components/TextOverlaySettingsBubble.js
+++ b/src/components/TextOverlaySettingsBubble.js
@@ -188,7 +188,6 @@ const ColorWidget = ({
           textColor: pageColors.map((cs) => cs.textColor).filter((x) => x)[0] ?? textColor,
           bgColor: pageColors.map((cs) => cs.bgColor).filter((x) => x)[0] ?? bgColor,
         })}
-        disabled={useAutoColors}
       >
         <ResetColorsIcon />
       </MiradorMenuButton>

--- a/src/components/TextOverlaySettingsBubble.js
+++ b/src/components/TextOverlaySettingsBubble.js
@@ -93,13 +93,16 @@ OpacityWidget.propTypes = {
 };
 
 /** Input to select a color */
-const ColorInput = ({ color, onChange, title }) => (
+const ColorInput = ({
+  color, onChange, title, style,
+}) => (
   <label
     style={{
       width: 48,
       height: 48,
       padding: 8,
       boxSizing: 'border-box',
+      ...style,
     }}
   >
     <div
@@ -126,6 +129,11 @@ ColorInput.propTypes = {
   color: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
   title: PropTypes.string.isRequired,
+  // eslint-disable-next-line react/forbid-prop-types
+  style: PropTypes.object,
+};
+ColorInput.defaultProps = {
+  style: {},
 };
 
 /** Widget to update text and background color */
@@ -151,11 +159,21 @@ const ColorWidget = ({
         title={t('textColor')}
         color={textColor}
         onChange={(color) => onChange({ textColor: color, bgColor })}
+        style={{
+          height: 40,
+          padding: '8px 8px 0px 8px',
+        }}
       />
       <ColorInput
         title={t('backgroundColor')}
         color={bgColor}
         onChange={(color) => onChange({ bgColor: color, textColor })}
+        style={{
+          marginTop: -6,
+          zIndex: -5,
+          height: 40,
+          padding: '0px 8px 8px 8px',
+        }}
       />
     </div>
   );

--- a/src/components/TextOverlaySettingsBubble.js
+++ b/src/components/TextOverlaySettingsBubble.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/label-has-associated-control */
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { MiradorMenuButton } from 'mirador/dist/es/src/components/MiradorMenuButton';
@@ -6,31 +7,12 @@ import TextIcon from '@material-ui/icons/TextFields';
 import CloseIcon from '@material-ui/icons/Close';
 import SubjectIcon from '@material-ui/icons/Subject';
 import OpacityIcon from '@material-ui/icons/Opacity';
+import PaletteIcon from '@material-ui/icons/Palette';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import useTheme from '@material-ui/core/styles/useTheme';
 
+import { changeAlpha } from '../lib/color';
 import TextSelectIcon from './TextSelectIcon';
-
-/**
- * Based on https://gist.github.com/danieliser/b4b24c9f772066bcf0a6
- */
-const changeAlpha = (color, opacity) => {
-  if (color[0] === '#') {
-    let hex = color.replace('#', '');
-    if (hex.length === 3) {
-      hex += hex;
-    }
-    const r = parseInt(hex.substring(0, 2), 16);
-    const g = parseInt(hex.substring(2, 4), 16);
-    const b = parseInt(hex.substring(4, 6), 16);
-    return `rgba(${r},${g},${b},${opacity})`;
-  }
-  if (color.startsWith('rgba')) {
-    return color.replace(/[^,]+(?=\))/, opacity);
-  }
-  console.error(`Unsupported color: ${color}`);
-  return color;
-};
 
 /** Control text overlay settings  */
 const TextOverlaySettingsBubble = ({
@@ -38,10 +20,12 @@ const TextOverlaySettingsBubble = ({
   textsFetching, updateWindowTextOverlayOptions, t,
 }) => {
   const {
-    enabled, visible, selectable, opacity,
+    enabled, visible, selectable, opacity, textColor, bgColor,
   } = windowTextOverlayOptions;
   const [open, setOpen] = useState(enabled && (visible || selectable));
   const [showOpacitySlider, setShowOpacitySlider] = useState(false);
+  const [showColorPicker, setShowColorPicker] = useState(false);
+
   const { palette } = useTheme();
   const bubbleBg = palette.shades.main;
   // CSS voodoo to render a border with a margin on the top and bottom
@@ -104,6 +88,9 @@ const TextOverlaySettingsBubble = ({
               if (showOpacitySlider && visible) {
                 setShowOpacitySlider(false);
               }
+              if (showColorPicker && visible) {
+                setShowColorPicker(false);
+              }
             }}
             aria-pressed={visible}
             style={{ backgroundColor: visible && toggledBubbleBg }}
@@ -112,12 +99,7 @@ const TextOverlaySettingsBubble = ({
           </MiradorMenuButton>
         </div>
         <div style={{
-          // CSS voodoo to render a border with a margin on the top and bottom
-          borderImageSlice: 1,
-          borderImageSource,
-          borderRight,
           display: 'inline-block',
-          paddingRight: 8,
         }}
         >
           <MiradorMenuButton
@@ -139,12 +121,12 @@ const TextOverlaySettingsBubble = ({
             data-test-id="text-opacity-slider"
             id="text-opacity-slider"
             aria-labelledby="text-opacity-slider-label"
+            className="MuiPaper-elevation4"
             style={{
               backgroundColor: changeAlpha(bubbleBg, 0.8),
-              borderRadius: 25,
+              borderRadius: '0px 0px 25px 25px',
               height: '150px',
-              marginTop: 2,
-              padding: 8,
+              padding: '16px 8px 8px 8px',
               position: 'absolute',
               top: 48,
               zIndex: 100,
@@ -161,6 +143,112 @@ const TextOverlaySettingsBubble = ({
                 opacity: val / 100.0,
               })}
             />
+          </div>
+          )}
+        </div>
+        <div
+          style={{
+            display: 'inline-block',
+            paddingRight: 8,
+            // CSS voodoo to render a border with a margin on the top and bottom
+            borderImageSlice: 1,
+            borderImageSource,
+            borderRight,
+          }}
+        >
+          <MiradorMenuButton
+            id="color-picker-label"
+            disabled={!visible}
+            aria-label={t('colorPicker')}
+            aria-controls="color-picker"
+            aria-expanded={showColorPicker}
+            onClick={() => setShowColorPicker(!showColorPicker)}
+            style={{
+              backgroundColor: showColorPicker && changeAlpha(bubbleFg, 0.1),
+            }}
+          >
+            <PaletteIcon />
+          </MiradorMenuButton>
+          {visible && showColorPicker
+          && (
+          <div
+            className="MuiPaper-elevation4"
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              position: 'absolute',
+              top: 48,
+              zIndex: 100,
+              borderRadius: '0 0 25px 25px',
+              backgroundColor: changeAlpha(bubbleBg, 0.8),
+            }}
+          >
+            <label
+              style={{
+                width: 48,
+                height: 48,
+                padding: 8,
+                boxSizing: 'border-box',
+              }}
+            >
+              <div
+                title={t('textColor')}
+                className="MuiPaper-elevation2"
+                style={{
+                  display: 'inline-block',
+                  width: 32,
+                  height: 32,
+                  borderRadius: 16,
+                  backgroundColor: textColor,
+                }}
+              />
+              <input
+                type="color"
+                value={textColor}
+                style={{ display: 'none' }}
+                onChange={(evt) => updateWindowTextOverlayOptions({
+                  ...windowTextOverlayOptions,
+                  textColor: evt.target.value,
+                })}
+                onInput={(evt) => updateWindowTextOverlayOptions({
+                  ...windowTextOverlayOptions,
+                  textColor: evt.target.value,
+                })}
+              />
+            </label>
+            <label
+              style={{
+                width: 48,
+                height: 48,
+                padding: 8,
+                boxSizing: 'border-box',
+              }}
+            >
+              <div
+                title={t('backgroundColor')}
+                className="MuiPaper-elevation2"
+                style={{
+                  display: 'inline-block',
+                  width: 32,
+                  height: 32,
+                  borderRadius: 16,
+                  backgroundColor: bgColor,
+                }}
+              />
+              <input
+                type="color"
+                value={bgColor}
+                style={{ display: 'none' }}
+                onChange={(evt) => updateWindowTextOverlayOptions({
+                  ...windowTextOverlayOptions,
+                  bgColor: evt.target.value,
+                })}
+                onInput={(evt) => updateWindowTextOverlayOptions({
+                  ...windowTextOverlayOptions,
+                  bgColor: evt.target.value,
+                })}
+              />
+            </label>
           </div>
           )}
         </div>

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,8 @@ export default [
         .map((canvasText) => ({
           ...canvasText.text,
           source: canvasText.source,
+          textColor: canvasText.textColor,
+          bgColor: canvasText.bgColor,
         })),
       windowId,
       ...getWindowTextOverlayOptions(state, { windowId }),
@@ -38,6 +40,8 @@ export default [
       imageToolsEnabled: getWindowConfig(state, { windowId }).imageToolsEnabled ?? false,
       textsAvailable: getTextsForVisibleCanvases(state, { windowId }).length > 0,
       textsFetching: getTextsForVisibleCanvases(state, { windowId }).some((t) => t.isFetching),
+      pageColors: getTextsForVisibleCanvases(state, { windowId })
+        .map(({ textColor, bgColor }) => ({ textColor, bgColor })),
       windowTextOverlayOptions: getWindowTextOverlayOptions(state, { windowId }),
     }),
     mode: 'add',

--- a/src/lib/color.js
+++ b/src/lib/color.js
@@ -14,7 +14,7 @@ export const changeAlpha = (color, opacity) => {
     const r = parseInt(hex.substring(0, 2), 16);
     const g = parseInt(hex.substring(2, 4), 16);
     const b = parseInt(hex.substring(4, 6), 16);
-    return `rgba(${r},${g},${b},${opacity})`;
+    return `rgba(${r}, ${g}, ${b}, ${opacity})`;
   }
   if (color.startsWith('rgba')) {
     return color.replace(/[^,]+(?=\))/, opacity);

--- a/src/lib/color.js
+++ b/src/lib/color.js
@@ -1,0 +1,24 @@
+/**
+ * Change alpha/opacity of a color.
+ *
+ * Input can be an RGB color as a hex string or in `rgba(...)` form.
+ *
+ * Based on https://gist.github.com/danieliser/b4b24c9f772066bcf0a6
+ */
+export const changeAlpha = (color, opacity) => {
+  if (color[0] === '#') {
+    let hex = color.replace('#', '');
+    if (hex.length === 3) {
+      hex += hex;
+    }
+    const r = parseInt(hex.substring(0, 2), 16);
+    const g = parseInt(hex.substring(2, 4), 16);
+    const b = parseInt(hex.substring(4, 6), 16);
+    return `rgba(${r},${g},${b},${opacity})`;
+  }
+  if (color.startsWith('rgba')) {
+    return color.replace(/[^,]+(?=\))/, opacity);
+  }
+  console.error(`Unsupported color: ${color}`);
+  return color;
+};

--- a/src/lib/color.js
+++ b/src/lib/color.js
@@ -1,3 +1,6 @@
+import flatten from 'lodash/flatten';
+import zip from 'lodash/zip';
+
 /**
  * Change alpha/opacity of a color.
  *
@@ -9,7 +12,7 @@ export const changeAlpha = (color, opacity) => {
   if (color[0] === '#') {
     let hex = color.replace('#', '');
     if (hex.length === 3) {
-      hex += hex;
+      hex = flatten(zip(Array.from(hex), Array.from(hex))).join('');
     }
     const r = parseInt(hex.substring(0, 2), 16);
     const g = parseInt(hex.substring(2, 4), 16);
@@ -19,6 +22,65 @@ export const changeAlpha = (color, opacity) => {
   if (color.startsWith('rgba')) {
     return color.replace(/[^,]+(?=\))/, opacity);
   }
+  if (color.startsWith('rgb')) {
+    return color.replace(/^rgb/, 'rgba').replace(/\)$/, `, ${opacity})`);
+  }
   console.error(`Unsupported color: ${color}`);
   return color;
 };
+
+/** Convert a rgb(...) or rgba(...) string to its hexadecimal representation. */
+export function toHexRgb(rgbColor) {
+  if (!rgbColor || !rgbColor.startsWith('rgb')) {
+    return rgbColor;
+  }
+  // eslint-disable-next-line prefer-template
+  return '#' + rgbColor.replace(/rgba?\((.+)\)/, '$1')
+    .split(',').slice(0, 3)
+    .map((x) => x.trim())
+    .map((x) => Number.parseInt(x, 10))
+    .map((x) => x.toString(16))
+    .join('');
+}
+
+/** Load image data for image */
+async function loadImage(imgUrl) {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.crossOrigin = 'Anonymous';
+    img.onload = () => {
+      const canvas = document.createElement('canvas');
+      const ctx = canvas.getContext('2d');
+      ctx.drawImage(img, 0, 0);
+      resolve(ctx.getImageData(0, 0, img.width, img.height).data);
+    };
+    img.onerror = reject;
+    img.src = imgUrl;
+  });
+}
+
+/** Determine foreground and background color from text image. */
+export async function getLineColors(imageService) {
+  // FIXME: This assumes a Level 2 endpoint, we should probably use one of the sizes listed
+  //        explicitely in the info response instead.
+  const imgUrl = `${imageService}/full/200,/0/default.jpg`;
+  const data = await loadImage(imgUrl);
+  const colors = {};
+  // Data is a flat array containing the image pixels as uint8 RGBA values in the range [0, 255]
+  for (let i = 0; i < data.length - 3; i += 4) {
+    const r = data[i];
+    const g = data[i + 1];
+    const b = data[i + 2];
+    const rgb = `rgb(${r},${g},${b})`;
+    colors[rgb] = (colors[rgb] ?? 0) + 1;
+  }
+  // Really simple algorithm: The most frequent color is always going to be the text color,
+  // the next most frequent color is the background. This can and should probably be tweaked
+  // with some heuristics in the future (converting to HSL seems worthwhile), but it's good
+  // enough for now.
+  const [textColor, bgColor] = Object.entries(colors)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 2)
+    .map(([k, v]) => k);
+  return { textColor, bgColor };
+}

--- a/src/locales.js
+++ b/src/locales.js
@@ -10,7 +10,7 @@ export default {
     colorPicker: 'Farbauswahl',
     textColor: 'Farbe für Text',
     backgroundColor: 'Farbe für Zeilenhintergrund',
-    resetColors: 'Farben zurücksetzen',
+    resetTextColors: 'Farben zurücksetzen',
   },
   en: {
     collapseTextOverlayOptions: 'Contract text overlay options',
@@ -23,6 +23,6 @@ export default {
     colorPicker: 'Color Picker',
     textColor: 'Text Color',
     backgroundColor: 'Line Background Color',
-    resetColors: 'Reset Colors',
+    resetTextColors: 'Reset Colors',
   },
 };

--- a/src/locales.js
+++ b/src/locales.js
@@ -10,6 +10,7 @@ export default {
     colorPicker: 'Farbauswahl',
     textColor: 'Farbe für Text',
     backgroundColor: 'Farbe für Zeilenhintergrund',
+    resetColors: 'Farben zurücksetzen',
   },
   en: {
     collapseTextOverlayOptions: 'Contract text overlay options',
@@ -22,5 +23,6 @@ export default {
     colorPicker: 'Color Picker',
     textColor: 'Text Color',
     backgroundColor: 'Line Background Color',
+    resetColors: 'Reset Colors',
   },
 };

--- a/src/locales.js
+++ b/src/locales.js
@@ -21,6 +21,6 @@ export default {
     textVisible: 'Text Visible',
     colorPicker: 'Color Picker',
     textColor: 'Text Color',
-    backgroundColor: 'Line Backgrouund Color',
+    backgroundColor: 'Line Background Color',
   },
 };

--- a/src/locales.js
+++ b/src/locales.js
@@ -7,6 +7,9 @@ export default {
     textOpacity: 'Text-Transparenz',
     textSelect: 'Text Auswählbar',
     textVisible: 'Text Sichtbar',
+    colorPicker: 'Farbauswahl',
+    textColor: 'Farbe für Text',
+    backgroundColor: 'Farbe für Zeilenhintergrund',
   },
   en: {
     collapseTextOverlayOptions: 'Contract text overlay options',
@@ -16,5 +19,8 @@ export default {
     textOpacity: 'Text Opacity',
     textSelect: 'Text Selectable',
     textVisible: 'Text Visible',
+    colorPicker: 'Color Picker',
+    textColor: 'Text Color',
+    backgroundColor: 'Line Backgrouund Color',
   },
 };

--- a/src/state/actions.js
+++ b/src/state/actions.js
@@ -3,6 +3,8 @@ export const PluginActionTypes = {
   RECEIVE_TEXT: 'mirador-textoverlay/RECEIVE_TEXT',
   RECEIVE_TEXT_FAILURE: 'mirador-textoverlay/RECEIVE_TEXT_FAILURE',
   REQUEST_TEXT: 'mirador-textoverlay/REQUEST_TEXT',
+  REQUEST_COLORS: 'mirador-textoverlay/REQUEST_COLORS',
+  RECEIVE_COLORS: 'mirador-textoverlay/RECEIVE_COLORS',
 };
 
 /**
@@ -68,5 +70,34 @@ export function receiveTextFailure(targetId, textUri, error) {
     targetId,
     textUri,
     type: PluginActionTypes.RECEIVE_TEXT_FAILURE,
+  };
+}
+
+/**
+ * requestColors - action creator
+ * @param {string} targetId
+ * @param {string} infoId
+ */
+export function requestColors(targetId, infoId) {
+  return {
+    targetId,
+    infoId,
+    type: PluginActionTypes.REQUEST_COLORS,
+  };
+}
+
+/**
+ * receiveColors - action creator
+ * @param {string} windowId
+ * @param {string} targetId
+ * @param {string} textColor
+ * @param {string} bgColor
+ */
+export function receiveColors(targetId, textColor, bgColor) {
+  return {
+    targetId,
+    textColor,
+    bgColor,
+    type: PluginActionTypes.RECEIVE_COLORS,
   };
 }

--- a/src/state/reducers.js
+++ b/src/state/reducers.js
@@ -56,6 +56,15 @@ export const textsReducer = (state = {}, action) => {
           sourceType: action.sourceType,
         },
       };
+    case PluginActionTypes.RECEIVE_COLORS:
+      return {
+        ...state,
+        [action.targetId]: {
+          ...state[action.targetId],
+          bgColor: action.bgColor,
+          textColor: action.textColor,
+        },
+      };
     default: return state;
   }
 };

--- a/src/state/selectors.js
+++ b/src/state/selectors.js
@@ -12,6 +12,10 @@ const defaultConfig = {
   selectable: false,
   // Overlay text overlay by default
   visible: false,
+  // Color of rendered text,
+  textColor: '#000000',
+  // Color of line background
+  bgColor: '#ffffff',
 };
 
 /** Selector to get text display options for a given window */

--- a/src/state/selectors.js
+++ b/src/state/selectors.js
@@ -1,6 +1,6 @@
 import { createSelector } from 'reselect';
 
-import { getCanvas, getWindowConfig, getVisibleCanvases } from 'mirador/dist/es/src/state/selectors';
+import { getWindowConfig, getVisibleCanvases } from 'mirador/dist/es/src/state/selectors';
 import { miradorSlice } from 'mirador/dist/es/src/state/selectors/utils';
 
 const defaultConfig = {
@@ -12,9 +12,11 @@ const defaultConfig = {
   selectable: false,
   // Overlay text overlay by default
   visible: false,
-  // Color of rendered text,
+  // Try to automatically determine the text and background color
+  useAutoColors: true,
+  // Color of rendered text, used as a fallback if auto-detection is enabled and fails
   textColor: '#000000',
-  // Color of line background
+  // Color of line background, used as a fallback if auto-detection is enabled and fails
   bgColor: '#ffffff',
 };
 
@@ -29,23 +31,6 @@ export const getWindowTextOverlayOptions = createSelector(
 
 /** Selector to get all loaded texts */
 export const getTexts = (state) => miradorSlice(state).texts;
-
-/** Selector for a single canvas' text */
-export const getTextForCanvas = createSelector(
-  [
-    getCanvas,
-    getTexts,
-  ],
-  (canvas, texts) => {
-    if (!texts || !canvas) return null;
-    if (!texts[canvas.id]) return null;
-
-    return texts[canvas.id] && {
-      ...texts[canvas.id].text,
-      source: texts[canvas.id].source,
-    };
-  },
-);
 
 /** Selector for text on all visible canvases */
 export const getTextsForVisibleCanvases = createSelector(


### PR DESCRIPTION
Implements https://github.com/dbmdz/mirador-textoverlay/issues/23.

By default, the plugin will now try to determine the text and background colors from the page image.
It now also offers a color picker widget that allows users to pick a custom color for text and line background, which will override the automatically determined colors. There's also a button to reset the colors to the automatic colors.

[![IdioticRepulsiveAcornwoodpecker-mobile](https://user-images.githubusercontent.com/608610/88822636-67978580-d1c4-11ea-82c1-4ddbf4e094bb.jpg)](https://gfycat.com/idioticrepulsiveacornwoodpecker)
[click image for video of demo](https://gfycat.com/idioticrepulsiveacornwoodpecker)

The behavior can be configured with three new configuration keys:
- `useAutoColors`: Try do determine page colors automatically and use them by default. Defaults to `true`
- `textColor`: Color for text. When `useAutoColors` is enabled, used as a fallback. Defaults to `#000000` (black)
- `bgColor`: Color for the line background. When `useAutoColors` is enabled, used as a fallback. Defaults to `#ffffff` (white)

If the auto-detection of the colors fails (most often due to missing CORS headers on image responses), the colors defined in `textColor` and `bgColor` will be used.