### PR TITLE
Track rotation and flipping of OSD viewport

### DIFF
--- a/src/components/MiradorTextOverlay.js
+++ b/src/components/MiradorTextOverlay.js
@@ -113,7 +113,7 @@ class MiradorTextOverlay extends Component {
         }
         transforms.push(`rotate(${rotation}deg)`);
       }
-      this.containerRef.current.style.transform = transforms.join('');
+      this.containerRef.current.style.transform = transforms.join(' ');
     }
     for (let itemNo = 0; itemNo < viewer.world.getItemCount(); itemNo += 1) {
       // Skip update if we don't have a reference to the PageTextDisplay instance

--- a/src/components/MiradorTextOverlay.js
+++ b/src/components/MiradorTextOverlay.js
@@ -89,23 +89,24 @@ class MiradorTextOverlay extends Component {
     const vpBounds = viewer.viewport.getBounds(true);
     const viewportZoom = viewer.viewport.getZoom(true);
     if (this.containerRef.current) {
+      const { clientWidth: containerWidth, clientHeight: containerHeight } = viewer.container;
       const flip = viewer.viewport.getFlip();
       const rotation = viewer.viewport.getRotation();
       const transforms = [];
       if (flip) {
-        transforms.push(`translate(${viewer.container.clientWidth}px, 0px)`);
+        transforms.push(`translate(${containerWidth}px, 0px)`);
         transforms.push('scale(-1, 1)');
       }
       if (rotation !== 0) {
         switch (rotation) {
           case 90:
-            transforms.push(`translate(${viewer.container.clientWidth}px, 0px)`);
+            transforms.push(`translate(${containerWidth}px, 0px)`);
             break;
           case 180:
-            transforms.push(`translate(${viewer.container.clientWidth}px, ${viewer.container.clientHeight}px)`);
+            transforms.push(`translate(${containerWidth}px, ${containerHeight}px)`);
             break;
           case 270:
-            transforms.push(`translate(0px, ${viewer.container.clientHeight}px)`);
+            transforms.push(`translate(0px, ${containerHeight}px)`);
             break;
           default:
             console.error(`Unsupported rotation: ${rotation}`);

--- a/src/components/PageTextDisplay.js
+++ b/src/components/PageTextDisplay.js
@@ -65,6 +65,8 @@ class PageTextDisplay extends React.Component {
       return;
     }
     const { width, height } = this.props;
+    // Scaling is done from the center of the container, so we have to update the
+    // horizontal and vertical offsets we got from OSD.
     const translateX = ((scaleFactor - 1) * width / 2) + (x * scaleFactor * -1);
     const translateY = ((scaleFactor - 1) * height / 2) + (y * scaleFactor * -1);
     const containerTransforms = [

--- a/src/index.js
+++ b/src/index.js
@@ -36,14 +36,24 @@ export default [
         updateWindow(windowId, { textOverlay: options }),
       ),
     }),
-    mapStateToProps: (state, { windowId }) => ({
-      imageToolsEnabled: getWindowConfig(state, { windowId }).imageToolsEnabled ?? false,
-      textsAvailable: getTextsForVisibleCanvases(state, { windowId }).length > 0,
-      textsFetching: getTextsForVisibleCanvases(state, { windowId }).some((t) => t.isFetching),
-      pageColors: getTextsForVisibleCanvases(state, { windowId })
-        .map(({ textColor, bgColor }) => ({ textColor, bgColor })),
-      windowTextOverlayOptions: getWindowTextOverlayOptions(state, { windowId }),
-    }),
+    mapStateToProps: (state, { windowId, PluginComponents }) => {
+      // Check if mirador-image-tools plugin is available. We can't rely on the presence of
+      // the `imageToolsEnabled` window option, since the plugin is currently enabled by default,
+      // even in the absence of the option.
+      // FIXME: This should be removed once ProjectMirador/mirador-image-tools#23 is merged
+      const imageToolsPresent = PluginComponents
+        .filter(({ WrappedComponent: { name } }) => name === 'MiradorImageTools')
+        .length > 0;
+      const { imageToolsEnabled } = getWindowConfig(state, { windowId });
+      return {
+        imageToolsEnabled: imageToolsEnabled ?? imageToolsPresent,
+        textsAvailable: getTextsForVisibleCanvases(state, { windowId }).length > 0,
+        textsFetching: getTextsForVisibleCanvases(state, { windowId }).some((t) => t.isFetching),
+        pageColors: getTextsForVisibleCanvases(state, { windowId })
+          .map(({ textColor, bgColor }) => ({ textColor, bgColor })),
+        windowTextOverlayOptions: getWindowTextOverlayOptions(state, { windowId }),
+      };
+    },
     mode: 'add',
     target: 'OpenSeadragonViewer',
   },


### PR DESCRIPTION
Implements https://github.com/dbmdz/mirador-textoverlay/issues/24.

This PR modifies the overlay so it tracks the OSD viewport's rotation and flipping state (used in https://github.com/ProjectMirador/mirador-image-tools):

![track-transforms](https://user-images.githubusercontent.com/608610/88913118-a418bf00-d260-11ea-8ffa-4bbb5dee09fe.gif)
