### PR TITLE
Actually disable selection instead of just changing the cursor

### DIFF
--- a/src/components/PageTextDisplay.js
+++ b/src/components/PageTextDisplay.js
@@ -113,7 +113,7 @@ class PageTextDisplay extends React.Component {
     const svgStyle = {
       width: pageWidth,
       height: pageHeight,
-      cursor: selectable ? undefined : 'default',
+      userSelect: selectable ? 'text' : 'none',
     };
     let fg = textColor;
     let bg = bgColor;


### PR DESCRIPTION
Previously we'd just change the cursor to `default`. This PR instead changes the `user-select` CSS property to `none` if text selection is disabled (`text` otherwise). This will also change the cursor, but also actually prevent the user from selecting text. Previously this would be a side-effect of us not stopping the `pointerDown` event from propagating to OSD, which caused issues on mobile, where a long-tap on e.g. Firefox would select the text even if selection was disabled.