### PR TITLE
Let pointerdown propagate if running on touch screen

### DIFF
--- a/__tests__/components/PageTextDisplay.test.js
+++ b/__tests__/components/PageTextDisplay.test.js
@@ -144,6 +144,21 @@ describe('PageTextDisplay', () => {
     expect(topCallback).not.toHaveBeenCalled();
   });
 
+  it('should let pointerdown events through if touch screen is detected', () => {
+    const origTouchStart = global.window.ontouchstart;
+    global.window.ontouchstart = true;
+    const topCallback = jest.fn();
+    const { rerender, container } = renderPage({ selectable: false });
+    container.addEventListener('pointerdown', topCallback);
+    fireEvent.pointerDown(screen.getByText(svgTextMatcher('a firstWord on a line')));
+    expect(topCallback).toHaveBeenCalled();
+    topCallback.mockClear();
+    renderPage({ selectable: true }, rerender);
+    fireEvent.pointerDown(screen.getByText(svgTextMatcher('a firstWord on a line')));
+    global.window.ontouchstart = origTouchStart;
+    expect(topCallback).toHaveBeenCalled();
+  });
+
   it('should render words as <text> elements when running under Gecko', () => {
     const prevAgent = global.navigator.userAgent;
     global.navigator.userAgent = 'Mozilla/5.0 (X11; Linux x86_64; rv:10.0) Gecko/20100101 Firefox/10.0';

--- a/src/components/PageTextDisplay.js
+++ b/src/components/PageTextDisplay.js
@@ -11,6 +11,17 @@ function runningInGecko() {
   return navigator.userAgent.indexOf('Gecko/') >= 0;
 }
 
+/** Check if we're running on a touch screen */
+function runningOnTouchScreen() {
+  return (
+    'ontouchstart' in window
+    || (window.DocumentTouch && document instanceof window.DocumentTouch)
+    || navigator.maxTouchPoints > 0
+    || window.navigator.msMaxTouchPoints > 0
+  );
+}
+
+
 /** Page Text Display component that is optimized for fast panning/zooming
  *
  * NOTE: This component is doing stuff that is NOT RECOMMENDED GENERALLY, like
@@ -50,7 +61,10 @@ class PageTextDisplay extends React.Component {
   /** Swallow pointer events if selection is enabled */
   onPointerDown = (evt) => {
     const { selectable } = this.props;
-    if (selectable) {
+    // Let pointerdown events propagate on touch screens. Text selection is initiated by a long
+    // press gesture there, and disabling pointer down events make text selection very difficult,
+    // without having a lot of advantages.
+    if (!runningOnTouchScreen() && selectable) {
       evt.stopPropagation();
     }
   };


### PR DESCRIPTION
On touch screens text selection is triggered by a long press, so we can let pointerdown events pass through to OSD if we detect one. This fixes problems with panning and zooming on mobile browsers when text selection was enabled.