### PR TITLE
Unify space handling between ALTO and hOCR.

### DIFF
--- a/__fixtures__/lines.json
+++ b/__fixtures__/lines.json
@@ -1,21 +1,25 @@
 {
-  "withWords": [
+  "withSpans": [
     {
       "x": 50,
       "y": 100,
       "width": 1800,
       "height": 120,
-      "words": [
+      "spans": [
         { "text": "a", "x": 50, "y": 100, "width": 50, "height": 120 },
+        { "text": " ", "x": 100, "y": 100, "width": 20, "height": 120 },
         {
-          "text": "firstWord ",
+          "text": "firstWord",
           "x": 120,
           "y": 100,
           "width": 220,
           "height": 120
         },
+        { "text": " ", "x": 340, "y": 100, "width": 20, "height": 120 },
         { "text": "on", "x": 360, "y": 100, "width": 100, "height": 120 },
+        { "text": " ", "x": 460, "y": 100, "width": 20, "height": 120 },
         { "text": "a", "x": 480, "y": 100, "width": 50, "height": 120 },
+        { "text": " ", "x": 530, "y": 100, "width": 20, "height": 120 },
         { "text": "line", "x": 550, "y": 100, "width": 260, "height": 120 }
       ]
     },
@@ -24,22 +28,26 @@
       "y": 240,
       "width": 1800,
       "height": 120,
-      "words": [
+      "spans": [
         { "text": "another", "x": 50, "y": 240, "width": 300, "height": 120 },
+        { "text": " ", "x": 350, "y": 240, "width": 20, "height": 120 },
         {
           "text": "secondWord",
-          "x": 420,
+          "x": 370,
           "y": 240,
           "width": 220,
           "height": 120
         },
-        { "text": "on", "x": 660, "y": 240, "width": 100, "height": 120 },
-        { "text": "another", "x": 780, "y": 240, "width": 300, "height": 120 },
-        { "text": "line", "x": 1150, "y": 240, "width": 260, "height": 120 }
+        { "text": " ", "x": 590, "y": 240, "width": 20, "height": 120 },
+        { "text": "on", "x": 610, "y": 240, "width": 100, "height": 120 },
+        { "text": " ", "x": 710, "y": 240, "width": 20, "height": 120 },
+        { "text": "another", "x": 730, "y": 240, "width": 300, "height": 120 },
+        { "text": " ", "x": 1030, "y": 240, "width": 20, "height": 120 },
+        { "text": "line", "x": 1050, "y": 240, "width": 260, "height": 120 }
       ]
     }
   ],
-  "withoutWords": [
+  "withoutSpans": [
     {
       "x": 50,
       "y": 100,

--- a/__tests__/components/PageTextDisplay.test.js
+++ b/__tests__/components/PageTextDisplay.test.js
@@ -17,7 +17,6 @@ function svgTextMatcher(text) {
     if (element.tagName === 'text') {
       const elementText = Array.from(element.querySelectorAll('tspan'))
         .map((el) => el.textContent)
-        .map((el) => (el.slice(-1) === ' ' ? el : `${el} `))
         .join('');
       return elementText.trimEnd() === text;
     }
@@ -37,7 +36,7 @@ function renderPage(props = {}, renderFn = render) {
       width={2100}
       height={2970}
       source="http://example.com/page/1"
-      lines={lineFixtures.withWords}
+      lines={lineFixtures.withSpans}
       bgColor="#ffffff"
       textColor="#000000"
       useAutoColors={false}
@@ -48,7 +47,7 @@ function renderPage(props = {}, renderFn = render) {
 }
 
 describe('PageTextDisplay', () => {
-  it('should render lines with individual words accurately', () => {
+  it('should render lines with individual spans accurately', () => {
     renderPage();
     const firstLine = screen.getByText(svgTextMatcher('a firstWord on a line'));
     expect(firstLine).not.toBeNull();
@@ -63,8 +62,8 @@ describe('PageTextDisplay', () => {
     expect(screen.getByText('secondWord')).not.toBeNull();
   });
 
-  it('should render lines without individual words accurately', () => {
-    renderPage({ lines: lineFixtures.withoutWords });
+  it('should render lines without individual spans accurately', () => {
+    renderPage({ lines: lineFixtures.withoutSpans });
     const firstLine = screen.getByText('a word on a line');
     expect(firstLine).not.toBeNull();
     expect(firstLine.previousElementSibling).toHaveAttribute('style', 'fill: rgba(255, 255, 255, 0.75);');
@@ -94,7 +93,7 @@ describe('PageTextDisplay', () => {
   it('should re-render when the source changes', () => {
     const { rerender } = renderPage();
     expect(screen.getByText(svgTextMatcher('a firstWord on a line'))).not.toBeNull();
-    renderPage({ source: 'http://example.com/pages/2', lines: lineFixtures.withoutWords, opacity: 0.25 }, rerender);
+    renderPage({ source: 'http://example.com/pages/2', lines: lineFixtures.withoutSpans, opacity: 0.25 }, rerender);
     expect(screen.getByText('a word on a line'))
       .toHaveAttribute('style', 'fill: rgba(0, 0, 0, 0.25);');
   });
@@ -144,7 +143,7 @@ describe('PageTextDisplay', () => {
     expect(topCallback).not.toHaveBeenCalled();
   });
 
-  it('should render words as <text> elements when running under Gecko', () => {
+  it('should render spans as <text> elements when running under Gecko', () => {
     const prevAgent = global.navigator.userAgent;
     global.navigator.userAgent = 'Mozilla/5.0 (X11; Linux x86_64; rv:10.0) Gecko/20100101 Firefox/10.0';
     renderPage();
@@ -152,15 +151,6 @@ describe('PageTextDisplay', () => {
     const word = screen.getByText('firstWord');
     expect(word).not.toBeNull();
     expect(word.tagName).toEqual('text');
-  });
-
-  it('should render words with smaller width in Gecko to account for rendering differences', () => {
-    const prevAgent = global.navigator.userAgent;
-    global.navigator.userAgent = 'Mozilla/5.0 (X11; Linux x86_64; rv:10.0) Gecko/20100101 Firefox/10.0';
-    renderPage();
-    global.navigator.userAgent = prevAgent;
-    const word = screen.getByText('firstWord');
-    expect(word).toHaveAttribute('textLength', '198');
   });
 
   it('should use automatically determined colors for the initial render if available and enabled', () => {

--- a/__tests__/lib/ocrFormats.test.js
+++ b/__tests__/lib/ocrFormats.test.js
@@ -30,16 +30,16 @@ describe('parsing ALTO', () => {
 
   it('should work for non-pixel based measurement units', () => {
     expect(parsed.lines).toHaveLength(402);
-    expect(parsed.lines[32].text).toEqual('par les agents de police à leur disposition,');
+    expect(parsed.lines[32].text).toEqual('par les agents de police à leur disposition,\n');
     expect(parsed.lines[64]).toMatchObject({
       height: closeTo(12.59),
-      text: 'seiller d\'Etat en mission extraordinaire.',
+      text: 'seiller d\'Etat en mission extraordinaire.\n',
       width: closeTo(244.48),
       x: closeTo(82.28),
       y: closeTo(1236.09),
     });
-    expect(parsed.lines[54].words).toHaveLength(9);
-    expect(parsed.lines[64].words[6]).toMatchObject({
+    expect(parsed.lines[54].spans).toHaveLength(9);
+    expect(parsed.lines[64].spans[6]).toMatchObject({
       height: closeTo(10.23),
       text: 'mission',
       width: closeTo(42.91),
@@ -49,12 +49,12 @@ describe('parsing ALTO', () => {
   });
 
   it('should not add newlines at the end of hyphenated lines', () => {
-    expect(parsed.lines[94].words[10].text).toMatch('exa');
-    expect(parsed.lines[96].words[16].text).toMatch('Débats\n');
+    expect(parsed.lines[94].spans[10].text).toMatch('exa');
+    expect(parsed.lines[96].spans[16].text).toMatch('Débats\n');
   });
 
   it('should convert style nodes to proper CSS', () => {
-    expect(parsed.lines[96].words[16].style)
+    expect(parsed.lines[96].spans[16].style)
       .toBe('font-family: Times New Roman;font-style: italic');
   });
 });
@@ -77,12 +77,19 @@ describe('parsing hOCR', () => {
       x: 219,
       y: 2097,
     });
-    expect(parsed.lines[29].words).toHaveLength(13);
-    expect(parsed.lines[29].words[7]).toMatchObject({
+    expect(parsed.lines[29].spans).toHaveLength(26);
+    expect(parsed.lines[29].spans[14]).toMatchObject({
       height: 56,
-      text: '„aber ',
-      width: 142.8,
+      text: '„aber',
+      width: 119,
       x: 922,
+      y: 2097,
+    });
+    expect(parsed.lines[29].spans[15]).toMatchObject({
+      height: 56,
+      text: ' ',
+      width: 21,
+      x: 1041,
       y: 2097,
     });
   });

--- a/src/components/MiradorTextOverlay.js
+++ b/src/components/MiradorTextOverlay.js
@@ -144,7 +144,7 @@ class MiradorTextOverlay extends Component {
   shouldRenderPage = ({ lines }) => (
     lines
     && lines.length > 0
-    && lines.some(({ text, words }) => text || (words && words.length > 0)))
+    && lines.some(({ text, spans }) => text || (spans && spans.length > 0)))
 
   /** If the overlay should be rendered at all */
   shouldRender(props) {

--- a/src/components/PageTextDisplay.js
+++ b/src/components/PageTextDisplay.js
@@ -130,21 +130,21 @@ class PageTextDisplay extends React.Component {
     /* Firefox/Gecko does not currently support the lengthAdjust parameter on
      * <tspan> Elements, only on <text> (https://bugzilla.mozilla.org/show_bug.cgi?id=890692).
      *
-     * Using <text> elements for words (and skipping the line-grouping) works fine
+     * Using <text> elements for spans (and skipping the line-grouping) works fine
      * in Firefox, but breaks selection behavior in Chrome (the selected text contains
      * a newline after every word).
      *
      * So we have to go against best practices and use user agent sniffing to determine dynamically
-     * how to render lines and words, sorry :-/ */
+     * how to render lines and spans, sorry :-/ */
     const isGecko = runningInGecko();
     // eslint-disable-next-line require-jsdoc
     let LineWrapper = ({ children }) => <text style={textStyle}>{children}</text>;
     // eslint-disable-next-line react/jsx-props-no-spreading, require-jsdoc
-    let WordElem = (props) => <tspan {...props} />;
+    let SpanElem = (props) => <tspan {...props} />;
     if (isGecko) {
       LineWrapper = React.Fragment;
       // eslint-disable-next-line react/jsx-props-no-spreading, require-jsdoc
-      WordElem = (props) => <text style={textStyle} {...props} />;
+      SpanElem = (props) => <text style={textStyle} {...props} />;
     }
     return (
       <div
@@ -165,32 +165,23 @@ class PageTextDisplay extends React.Component {
             ))}
 
             {renderLines.map((line) => (
-              line.words
+              line.spans
                 ? (
                   <LineWrapper key={`line-${line.x}-${line.y}`}>
-                    {line.words.filter((w) => w.width > 0 && w.height > 0).map(({
+                    {line.spans.filter((w) => w.width > 0 && w.height > 0).map(({
                       x, y, width, text,
-                    }) => {
-                      // Another ugly user agent sniffing hack:
-                      // In Gecko, whitespace is not stretched, unlike in Chrome.
-                      // Thus. we have to exclude the space's width from the rendered word's width.
-                      let renderWidth = width;
-                      if (isGecko && text.slice(-1) === ' ') {
-                        renderWidth -= (renderWidth / text.length);
-                      }
-                      return (
-                        <WordElem
-                          key={`text-${x}-${y}`}
-                          x={x}
-                          y={line.y + line.height * 0.75}
-                          textLength={renderWidth}
-                          fontSize={`${line.height * 0.75}px`}
-                          lengthAdjust="spacingAndGlyphs"
-                        >
-                          {text}
-                        </WordElem>
-                      );
-                    })}
+                    }) => (
+                      <SpanElem
+                        key={`text-${x}-${y}`}
+                        x={x}
+                        y={line.y + line.height * 0.75}
+                        textLength={width}
+                        fontSize={`${line.height * 0.75}px`}
+                        lengthAdjust="spacingAndGlyphs"
+                      >
+                        {text}
+                      </SpanElem>
+                    ))}
                   </LineWrapper>
                 )
                 : (

--- a/src/lib/ocrFormats.js
+++ b/src/lib/ocrFormats.js
@@ -43,7 +43,7 @@ function parseHocrNode(node, endOfLine = false, scaleFactor = 1) {
   if (node.nextSibling instanceof Text) {
     let extraText = node.nextSibling.wholeText.replace(/\s+/, ' ');
     if (endOfLine && spans[0].text.slice(-1) !== '\u00AD') {
-      // Add newline if the line does not end on a hyphenation
+      // Add newline if the line does not end on a hyphenation (a soft hyphen)
       extraText = `${extraText.trim()}\n`;
     }
     if (extraText.length > 0) {


### PR DESCRIPTION
Previously, we would add word tokens for space characters if an ALTO document encoded spaces, and otherwise expand existing words with whitespace if it didn't (always the case for hOCR).

This required a bunch of guesstimating and brittle hacks, so now we instead opt to use the space between existing words for whitespace uniformly.

This also renames `word` (which would now be misleading, since it can also contain only whitespace) to `span`.