### PR TITLE
Improve performance of selection/visibility toggles

### DIFF
--- a/__tests__/components/PageTextDisplay.test.js
+++ b/__tests__/components/PageTextDisplay.test.js
@@ -128,17 +128,11 @@ describe('PageTextDisplay', () => {
   });
 
   it('should render text invisible if visibility is disabled', () => {
-    const { container, rerender } = renderPage();
-    container.querySelectorAll('rect').forEach(
-      (rect) => expect(rect).toHaveAttribute('style', 'fill: rgba(255, 255, 255, 0.75);'),
-    );
-    let firstLine = screen.getByText(svgTextMatcher('a firstWord on a line'));
-    expect(firstLine).toHaveAttribute('style', 'fill: rgba(0, 0, 0, 0.75);');
-    renderPage({ visible: false }, rerender);
+    const { container } = renderPage({ visible: false });
     container.querySelectorAll('rect').forEach(
       (rect) => expect(rect).toHaveAttribute('style', 'fill: rgba(255, 255, 255, 0);'),
     );
-    firstLine = screen.getByText(svgTextMatcher('a firstWord on a line'));
+    const firstLine = screen.getByText(svgTextMatcher('a firstWord on a line'));
     expect(firstLine).toHaveAttribute('style', 'fill: rgba(0, 0, 0, 0);');
   });
 
@@ -168,6 +162,13 @@ describe('PageTextDisplay', () => {
     fireEvent.pointerDown(screen.getByText(svgTextMatcher('a firstWord on a line')));
     global.window.ontouchstart = origTouchStart;
     expect(topCallback).toHaveBeenCalled();
+  });
+
+  it('should disable text selection if selection is disabled', () => {
+    const { ref, container } = renderPage();
+    expect(container.querySelectorAll('svg')[1]).toHaveStyle('user-select: text');
+    ref.current.updateSelectability(false);
+    expect(container.querySelectorAll('svg')[1]).not.toHaveStyle('user-select: text');
   });
 
   it('should render spans as <text> elements when running under Gecko', () => {

--- a/src/components/PageTextDisplay.js
+++ b/src/components/PageTextDisplay.js
@@ -51,12 +51,8 @@ class PageTextDisplay extends React.Component {
    * but this way we can more precisely control when we re-render.
    */
   shouldComponentUpdate(nextProps) {
-    const { source, selectable, visible } = this.props;
-    return (
-      nextProps.source !== source
-      || nextProps.selectable !== selectable
-      || nextProps.visible !== visible
-    );
+    const { source } = this.props;
+    return nextProps.source !== source;
   }
 
   /** Swallow pointer events if selection is enabled */
@@ -109,6 +105,17 @@ class PageTextDisplay extends React.Component {
     for (const text of this.textContainerRef.current.querySelectorAll('text')) {
       text.style.fill = changeAlpha(textColor, opacity);
     }
+  }
+
+  /** Update the selectability of the text nodes.
+   *
+   * Again, intended to be called from the parent, again for performance reasons.
+   */
+  updateSelectability(selectable) {
+    if (!this.textContainerRef.current) {
+      return;
+    }
+    this.textContainerRef.current.parentElement.style.userSelect = selectable ? 'text' : 'none';
   }
 
   /** Render the page overlay */

--- a/src/components/TextOverlaySettingsBubble.js
+++ b/src/components/TextOverlaySettingsBubble.js
@@ -78,7 +78,7 @@ const OpacityWidget = ({ opacity, onChange, t }) => {
     >
       <Slider
         orientation="vertical"
-        min={0}
+        min={1}
         max={100}
         value={opacity * 100}
         getAriaValueText={(value) => t('opacityCurrentValue', { value })}

--- a/src/index.js
+++ b/src/index.js
@@ -36,17 +36,10 @@ export default [
         updateWindow(windowId, { textOverlay: options }),
       ),
     }),
-    mapStateToProps: (state, { windowId, PluginComponents }) => {
-      // Check if mirador-image-tools plugin is available. We can't rely on the presence of
-      // the `imageToolsEnabled` window option, since the plugin is currently enabled by default,
-      // even in the absence of the option.
-      // FIXME: This should be removed once ProjectMirador/mirador-image-tools#23 is merged
-      const imageToolsPresent = PluginComponents
-        .filter(({ WrappedComponent: { name } }) => name === 'MiradorImageTools')
-        .length > 0;
+    mapStateToProps: (state, { windowId }) => {
       const { imageToolsEnabled } = getWindowConfig(state, { windowId });
       return {
-        imageToolsEnabled: imageToolsEnabled ?? imageToolsPresent,
+        imageToolsEnabled,
         textsAvailable: getTextsForVisibleCanvases(state, { windowId }).length > 0,
         textsFetching: getTextsForVisibleCanvases(state, { windowId }).some((t) => t.isFetching),
         pageColors: getTextsForVisibleCanvases(state, { windowId })


### PR DESCRIPTION
Just like with opacity and the colors, we can achieve better performance by going around React for these updates.
Additionally, we remove the hacky check for the presence of the mirador-image-tools plugin, since it broke once minification/uglification was enabled.