### PR TITLE
Make text font configurable, default to theme font

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ const miradorConfig = {
       selectable: true,  // allow selecting the text, also works if text is not visible,
       visible: true, // enable visible rendering of the text
       opacity: 0.5, // default opacity for the rendered text
+      fontFamily: ['Comic Sans MS', 'sans-serif']  // text font, defaults to the theme's font
     }
   }
 }

--- a/src/components/MiradorTextOverlay.js
+++ b/src/components/MiradorTextOverlay.js
@@ -164,6 +164,7 @@ class MiradorTextOverlay extends Component {
   render() {
     const {
       pageTexts, selectable, visible, viewer, opacity, textColor, bgColor, useAutoColors,
+      fontFamily,
     } = this.props;
     if (!this.shouldRender() || !viewer || !pageTexts) {
       return null;
@@ -190,6 +191,7 @@ class MiradorTextOverlay extends Component {
                 width={pageWidth}
                 height={pageHeight}
                 textColor={textColor}
+                fontFamily={fontFamily}
                 bgColor={bgColor}
                 useAutoColors={useAutoColors}
                 pageColors={pageFg ? { textColor: pageFg, bgColor: pageBg } : undefined}
@@ -211,6 +213,7 @@ MiradorTextOverlay.propTypes = {
   viewer: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   visible: PropTypes.bool,
   textColor: PropTypes.string,
+  fontFamily: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
   bgColor: PropTypes.string,
   useAutoColors: PropTypes.bool,
 };
@@ -224,6 +227,7 @@ MiradorTextOverlay.defaultProps = {
   viewer: undefined,
   visible: false,
   textColor: '#000000',
+  fontFamily: undefined,
   bgColor: '#ffffff',
   useAutoColors: true,
 };

--- a/src/components/PageTextDisplay.js
+++ b/src/components/PageTextDisplay.js
@@ -115,7 +115,7 @@ class PageTextDisplay extends React.Component {
   render() {
     const {
       selectable, visible, lines, width: pageWidth, height: pageHeight, opacity, textColor, bgColor,
-      useAutoColors, pageColors,
+      useAutoColors, pageColors, fontFamily,
     } = this.props;
 
     const containerStyle = {
@@ -141,7 +141,10 @@ class PageTextDisplay extends React.Component {
 
     const renderOpacity = (!visible && selectable) ? 0 : opacity;
     const boxStyle = { fill: changeAlpha(bg, renderOpacity) };
-    const textStyle = { fill: changeAlpha(fg, renderOpacity) };
+    const textStyle = {
+      fill: changeAlpha(fg, renderOpacity),
+      fontFamily,
+    };
     const renderLines = lines.filter((l) => l.width > 0 && l.height > 0);
 
     /* Firefox/Gecko does not currently support the lengthAdjust parameter on
@@ -242,6 +245,7 @@ PageTextDisplay.propTypes = {
   visible: PropTypes.bool.isRequired,
   opacity: PropTypes.number.isRequired,
   textColor: PropTypes.string.isRequired,
+  fontFamily: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
   bgColor: PropTypes.string.isRequired,
   useAutoColors: PropTypes.bool.isRequired,
   width: PropTypes.number.isRequired,
@@ -254,6 +258,9 @@ PageTextDisplay.propTypes = {
 };
 PageTextDisplay.defaultProps = {
   pageColors: undefined,
+};
+PageTextDisplay.defaultProps = {
+  fontFamily: undefined,
 };
 
 export default PageTextDisplay;

--- a/src/state/selectors.js
+++ b/src/state/selectors.js
@@ -1,6 +1,8 @@
 import { createSelector } from 'reselect';
 
-import { getWindowConfig, getVisibleCanvases } from 'mirador/dist/es/src/state/selectors';
+import {
+  getWindowConfig, getVisibleCanvases, getTheme,
+} from 'mirador/dist/es/src/state/selectors';
 import { miradorSlice } from 'mirador/dist/es/src/state/selectors/utils';
 
 const defaultConfig = {
@@ -22,8 +24,9 @@ const defaultConfig = {
 
 /** Selector to get text display options for a given window */
 export const getWindowTextOverlayOptions = createSelector(
-  [getWindowConfig],
-  ({ textOverlay }) => ({
+  [getWindowConfig, getTheme],
+  ({ textOverlay }, { typography: { fontFamily } }) => ({
+    fontFamily,
     ...defaultConfig,
     ...(textOverlay ?? {}),
   }),


### PR DESCRIPTION
Adds a new `fontFamily` configuration key that allows users to override the font used for rendering the text. The default font is now the font defined in the MaterialUI theme (or the user's theme, if provided in the Mirador config).

Allows things like this:
![yay](https://user-images.githubusercontent.com/608610/89201305-8ecdc880-d5b1-11ea-851f-1e1d89b19629.png)
