### PR TITLE
Fix hOCR end-of-line whitespace handling

### DIFF
--- a/__tests__/lib/ocrFormats.test.js
+++ b/__tests__/lib/ocrFormats.test.js
@@ -76,7 +76,7 @@ describe('parsing hOCR', () => {
       x: 219,
       y: 2097,
     });
-    expect(parsed.lines[29].spans).toHaveLength(26);
+    expect(parsed.lines[29].spans).toHaveLength(25);
     expect(parsed.lines[29].spans[14]).toMatchObject({
       height: 56,
       text: '„aber',
@@ -90,6 +90,13 @@ describe('parsing hOCR', () => {
       width: 21,
       x: 1041,
       y: 2097,
+    });
+    expect(parsed.lines[29].spans[24]).toMatchObject({
+      height: 26,
+      text: '—,\n',
+      width: 70,
+      x: 1453,
+      y: 2121,
     });
   });
 

--- a/src/components/PageTextDisplay.js
+++ b/src/components/PageTextDisplay.js
@@ -137,6 +137,7 @@ class PageTextDisplay extends React.Component {
       width: pageWidth,
       height: pageHeight,
       userSelect: selectable ? 'text' : 'none',
+      whiteSpace: 'pre',
     };
     let fg = textColor;
     let bg = bgColor;

--- a/src/lib/ocrFormats.js
+++ b/src/lib/ocrFormats.js
@@ -41,9 +41,9 @@ function parseHocrNode(node, endOfLine = false, scaleFactor = 1) {
   // Add an extra space span if the following text node contains something
   if (node.nextSibling instanceof Text) {
     let extraText = node.nextSibling.wholeText.replace(/\s+/, ' ');
-    if (endOfLine && spans[0].text.slice(-1) !== '\u00AD') {
-      // Add newline if the line does not end on a hyphenation (a soft hyphen)
-      extraText = `${extraText.trim()}\n`;
+    if (endOfLine) {
+      // We don't need trailing whitespace
+      extraText = extraText.trimEnd();
     }
     if (extraText.length > 0) {
       spans.push({
@@ -56,6 +56,11 @@ function parseHocrNode(node, endOfLine = false, scaleFactor = 1) {
         isExtra: true,
       });
     }
+  }
+  const lastSpan = spans.slice(-1)[0];
+  if (endOfLine && lastSpan.text.slice(-1) !== '\u00AD') {
+    // Add newline if the line does not end on a hyphenation (a soft hyphen)
+    lastSpan.text += '\n';
   }
   return spans;
 }


### PR DESCRIPTION
hOCR lines that don't end on hyphenation now end correctly with a newline character in their last span's text.
Additionally, this commit improves whitespace rendering by setting the CSS `white-space` option to `pre`. This removes the ugly gaps between text-spans when selecting text.