### PR TITLE
Use MUI's fade function instead of custom changeAlpha

### DIFF
--- a/__tests__/lib/color.test.js
+++ b/__tests__/lib/color.test.js
@@ -1,26 +1,4 @@
-import { changeAlpha, toHexRgb, getPageColors } from '../../src/lib/color';
-
-describe('changeAlpha', () => {
-  it('Should work with 6-digit hex colors', () => {
-    expect(changeAlpha('#ffffff', 0.5)).toEqual('rgba(255, 255, 255, 0.5)');
-  });
-  it('Should work with 3-digit hex colors', () => {
-    expect(changeAlpha('#abc', 0.5)).toEqual('rgba(170, 187, 204, 0.5)');
-  });
-  it('Should work with rbga colors', () => {
-    expect(changeAlpha('rgba(123, 221, 100, 0.1)', 0.5)).toEqual('rgba(123, 221, 100,0.5)');
-  });
-  it('Should work with rgb colors', () => {
-    expect(changeAlpha('rgb(123, 221, 100)', 0.5)).toEqual('rgba(123, 221, 100, 0.5)');
-  });
-  it('Should return unsupported colors unmodified', () => {
-    const origError = console.error;
-    console.error = jest.fn();
-    expect(changeAlpha('hsv(210, 17, 80)', 0.5)).toEqual('hsv(210, 17, 80)');
-    expect(console.error).toHaveBeenCalledWith('Unsupported color: hsv(210, 17, 80)');
-    console.error = origError;
-  });
-});
+import { toHexRgb, getPageColors } from '../../src/lib/color';
 
 describe('toHexRgb', () => {
   it('Should work with rgb strings', () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mirador-textoverlay",
-  "version": "0.3.1",
+  "version": "0.3.2-pre",
   "description": "Mirador 3 plugin to render a hidden (but selectable) or visible text overlay",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/components/PageTextDisplay.js
+++ b/src/components/PageTextDisplay.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
-import { changeAlpha } from '../lib/color';
+import { fade } from '@material-ui/core/styles/colorManipulator';
 
 /** Check if we're running in Gecko */
 function runningInGecko() {
@@ -96,10 +95,10 @@ class PageTextDisplay extends React.Component {
     // one of the containers, since otherwise the user's selection highlight would
     // become transparent as well or disappear entirely.
     for (const rect of this.boxContainerRef.current.querySelectorAll('rect')) {
-      rect.style.fill = changeAlpha(bgColor, opacity);
+      rect.style.fill = fade(bgColor, opacity);
     }
     for (const text of this.textContainerRef.current.querySelectorAll('text')) {
-      text.style.fill = changeAlpha(textColor, opacity);
+      text.style.fill = fade(textColor, opacity);
     }
   }
 
@@ -144,9 +143,9 @@ class PageTextDisplay extends React.Component {
     }
 
     const renderOpacity = (!visible && selectable) ? 0 : opacity;
-    const boxStyle = { fill: changeAlpha(bg, renderOpacity) };
+    const boxStyle = { fill: fade(bg, renderOpacity) };
     const textStyle = {
-      fill: changeAlpha(fg, renderOpacity),
+      fill: fade(fg, renderOpacity),
       fontFamily,
     };
     const renderLines = lines.filter((l) => l.width > 0 && l.height > 0);

--- a/src/components/TextOverlaySettingsBubble.js
+++ b/src/components/TextOverlaySettingsBubble.js
@@ -11,8 +11,9 @@ import PaletteIcon from '@material-ui/icons/Palette';
 import ResetColorsIcon from '@material-ui/icons/SettingsBackupRestore';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import useTheme from '@material-ui/core/styles/useTheme';
+import { fade } from '@material-ui/core/styles/colorManipulator';
 
-import { changeAlpha, toHexRgb } from '../lib/color';
+import { toHexRgb } from '../lib/color';
 import TextSelectIcon from './TextSelectIcon';
 
 /** Container for a settings button */
@@ -31,10 +32,10 @@ const ButtonContainer = ({
   if (withBorder) {
     // CSS voodoo to render a border with a margin on the top and bottom
     style.borderImageSource = 'linear-gradient('
-    + `to bottom, ${changeAlpha(bubbleFg, 0)}) 20%,`
-    + `${changeAlpha(bubbleFg, 0.2)} 20% 80%,`
-    + `${changeAlpha(bubbleFg, 0)} 80%`;
-    style.borderRight = `1px solid ${changeAlpha(bubbleFg, 0.2)}`;
+    + `to bottom, ${fade(bubbleFg, 0)}) 20%,`
+    + `${fade(bubbleFg, 0.2)} 20% 80%,`
+    + `${fade(bubbleFg, 0)} 80%`;
+    style.borderRight = `1px solid ${fade(bubbleFg, 0.2)}`;
     style.borderImageSlice = 1;
   }
   return (
@@ -66,7 +67,7 @@ const OpacityWidget = ({ opacity, onChange, t }) => {
       aria-labelledby="text-opacity-slider-label"
       className="MuiPaper-elevation4"
       style={{
-        backgroundColor: changeAlpha(bubbleBg, 0.8),
+        backgroundColor: fade(bubbleBg, 0.8),
         borderRadius: '0px 0px 25px 25px',
         height: '150px',
         padding: '16px 8px 8px 8px',
@@ -176,7 +177,7 @@ const ColorWidget = ({
         top: 48,
         zIndex: 100,
         borderRadius: '0 0 25px 25px',
-        backgroundColor: changeAlpha(bubbleBg, 0.8),
+        backgroundColor: fade(bubbleBg, 0.8),
       }}
     >
       {showResetButton && (
@@ -264,7 +265,7 @@ const TextOverlaySettingsBubble = ({
   const { palette } = useTheme();
   const bubbleBg = palette.shades.main;
   const bubbleFg = palette.getContrastText(bubbleBg);
-  const toggledBubbleBg = changeAlpha(bubbleFg, 0.25);
+  const toggledBubbleBg = fade(bubbleFg, 0.25);
 
   if (!enabled || !textsAvailable) {
     return null;
@@ -273,7 +274,7 @@ const TextOverlaySettingsBubble = ({
     <div
       className="MuiPaper-elevation4"
       style={{
-        backgroundColor: changeAlpha(bubbleBg, 0.8),
+        backgroundColor: fade(bubbleBg, 0.8),
         borderRadius: 25,
         position: 'absolute',
         right: 8,
@@ -329,7 +330,7 @@ const TextOverlaySettingsBubble = ({
             aria-expanded={showOpacitySlider}
             onClick={() => setShowOpacitySlider(!showOpacitySlider)}
             style={{
-              backgroundColor: showOpacitySlider && changeAlpha(bubbleFg, 0.1),
+              backgroundColor: showOpacitySlider && fade(bubbleFg, 0.1),
             }}
           >
             <OpacityIcon />
@@ -355,7 +356,7 @@ const TextOverlaySettingsBubble = ({
             aria-expanded={showColorPicker}
             onClick={() => setShowColorPicker(!showColorPicker)}
             style={{
-              backgroundColor: showColorPicker && changeAlpha(bubbleFg, 0.1),
+              backgroundColor: showColorPicker && fade(bubbleFg, 0.1),
             }}
           >
             <PaletteIcon />

--- a/src/lib/color.js
+++ b/src/lib/color.js
@@ -1,34 +1,3 @@
-import flatten from 'lodash/flatten';
-import zip from 'lodash/zip';
-
-/**
- * Change alpha/opacity of a color.
- *
- * Input can be an RGB color as a hex string or in `rgba(...)` form.
- *
- * Based on https://gist.github.com/danieliser/b4b24c9f772066bcf0a6
- */
-export const changeAlpha = (color, opacity) => {
-  if (color[0] === '#') {
-    let hex = color.replace('#', '');
-    if (hex.length === 3) {
-      hex = flatten(zip(Array.from(hex), Array.from(hex))).join('');
-    }
-    const r = parseInt(hex.substring(0, 2), 16);
-    const g = parseInt(hex.substring(2, 4), 16);
-    const b = parseInt(hex.substring(4, 6), 16);
-    return `rgba(${r}, ${g}, ${b}, ${opacity})`;
-  }
-  if (color.startsWith('rgba')) {
-    return color.replace(/[^,]+(?=\))/, opacity);
-  }
-  if (color.startsWith('rgb')) {
-    return color.replace(/^rgb/, 'rgba').replace(/\)$/, `, ${opacity})`);
-  }
-  console.error(`Unsupported color: ${color}`);
-  return color;
-};
-
 /** Convert a rgb(...) or rgba(...) string to its hexadecimal representation. */
 export function toHexRgb(rgbColor) {
   if (!rgbColor || !rgbColor.startsWith('rgb')) {


### PR DESCRIPTION
Turns out MaterialUI already has code for changing a color's opacity, so we now just use that instead of our own custom code. Thanks to @mejackreed for pointing this out in another review!