### PR TITLE
Add missing containerId prop to all MiradorMenuButton instances

### DIFF
--- a/src/components/settings/ColorWidget.js
+++ b/src/components/settings/ColorWidget.js
@@ -58,7 +58,7 @@ const useStyles = makeStyles(({ palette, breakpoints }) => {
 
 /** Widget to update text and background color */
 const ColorWidget = ({
-  textColor, bgColor, onChange, t, pageColors, useAutoColors,
+  textColor, bgColor, onChange, t, pageColors, useAutoColors, containerId,
 }) => {
   const showResetButton = (
     !useAutoColors
@@ -71,6 +71,7 @@ const ColorWidget = ({
     <div className={`MuiPaper-elevation4 ${classes.root}`}>
       {showResetButton && (
       <MiradorMenuButton
+        containerId={containerId}
         aria-label={t('resetTextColors')}
         onClick={() => onChange({
           useAutoColors: true,
@@ -118,6 +119,7 @@ const ColorWidget = ({
   );
 };
 ColorWidget.propTypes = {
+  containerId: PropTypes.string.isRequired,
   textColor: PropTypes.string.isRequired,
   bgColor: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,

--- a/src/components/settings/OverlaySettings.js
+++ b/src/components/settings/OverlaySettings.js
@@ -49,6 +49,7 @@ const useStyles = makeStyles(({ palette, breakpoints }) => {
 const OverlaySettings = ({
   windowTextOverlayOptions, imageToolsEnabled, textsAvailable,
   textsFetching, updateWindowTextOverlayOptions, t, pageColors,
+  containerId,
 }) => {
   const {
     enabled, visible, selectable, opacity, textColor: defaultTextColor, bgColor: defaultBgColor,
@@ -85,6 +86,7 @@ const OverlaySettings = ({
   const toggleButton = (
     <ButtonContainer withBorder={!textsFetching && open && isSmallDisplay}>
       <MiradorMenuButton
+        containerId={containerId}
         aria-label={open ? t('collapseTextOverlayOptions') : t('expandTextOverlayOptions')}
         disabled={textsFetching}
         onClick={() => setOpen(!open)}
@@ -103,6 +105,7 @@ const OverlaySettings = ({
       <>
         <ButtonContainer withBorder paddingPrev={isSmallDisplay ? 8 : 0} paddingNext={8}>
           <MiradorMenuButton
+            containerId={containerId}
             aria-label={t('textSelect')}
             onClick={() => updateWindowTextOverlayOptions({
               ...windowTextOverlayOptions,
@@ -116,6 +119,7 @@ const OverlaySettings = ({
         </ButtonContainer>
         <ButtonContainer paddingPrev={8}>
           <MiradorMenuButton
+            containerId={containerId}
             aria-label={t('textVisible')}
             onClick={() => {
               updateWindowTextOverlayOptions({
@@ -138,6 +142,7 @@ const OverlaySettings = ({
         <ButtonContainer>
           <MiradorMenuButton
             id="text-opacity-slider-label"
+            containerId={containerId}
             disabled={!visible}
             aria-label={t('textOpacity')}
             aria-controls="text-opacity-slider"
@@ -164,6 +169,7 @@ const OverlaySettings = ({
         <ButtonContainer withBorder={!isSmallDisplay} paddingNext={isSmallDisplay ? 0 : 8}>
           <MiradorMenuButton
             id="color-picker-label"
+            containerId={containerId}
             disabled={!visible}
             aria-label={t('colorPicker')}
             aria-controls="color-picker"
@@ -179,6 +185,7 @@ const OverlaySettings = ({
           && (
           <ColorWidget
             t={t}
+            containerId={containerId}
             bgColor={bgColor}
             textColor={textColor}
             pageColors={pageColors}
@@ -200,6 +207,7 @@ const OverlaySettings = ({
 };
 
 OverlaySettings.propTypes = {
+  containerId: PropTypes.string.isRequired,
   imageToolsEnabled: PropTypes.bool.isRequired,
   t: PropTypes.func.isRequired,
   textsAvailable: PropTypes.bool.isRequired,

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import { updateWindow } from 'mirador/dist/es/src/state/actions';
-import { getWindowConfig } from 'mirador/dist/es/src/state/selectors';
+import { getWindowConfig, getContainerId } from 'mirador/dist/es/src/state/selectors';
 
 import { textsReducer } from './state/reducers';
 import textSaga from './state/sagas';
@@ -39,6 +39,7 @@ export default [
     mapStateToProps: (state, { windowId }) => {
       const { imageToolsEnabled } = getWindowConfig(state, { windowId });
       return {
+        containerId: getContainerId(state),
         imageToolsEnabled,
         textsAvailable: getTextsForVisibleCanvases(state, { windowId }).length > 0,
         textsFetching: getTextsForVisibleCanvases(state, { windowId }).some((t) => t.isFetching),


### PR DESCRIPTION
This had the effect of making button popovers disappear in fullscreen mode, since the popovers would be  rendered as a child of the body element, which was not in fullscreen scope.