### PR TITLE
Fix bug when initial plugin state is !visible && !selectable

### DIFF
--- a/__tests__/components/OverlaySettings.test.js
+++ b/__tests__/components/OverlaySettings.test.js
@@ -62,6 +62,7 @@ function renderSettings(props = {}, renderFn = render) {
   const { rerender } = renderFn(
     <ThemeProvider theme={mockTheme}>
       <OverlaySettings
+        containerId="foobar"
         imageToolsEnabled={false}
         t={(key) => key}
         textsAvailable

--- a/__tests__/state/sagas.test.js
+++ b/__tests__/state/sagas.test.js
@@ -306,7 +306,7 @@ describe('Reacting to configuration changes', () => {
       { id: windowId, payload: { textOverlay: { ...config, selectable: true } } },
     ).provide([
       [select(getTextsForVisibleCanvases, { windowId }),
-        [{ sourceType: 'annos' }, { sourceType: 'ocr' }]],
+        [{ sourceType: 'annos' }, { sourceType: 'ocr', text: { } }]],
       [select(getVisibleCanvases, { windowId }),
         [{ id: 'canvasA' }, { id: 'canvasB' }]],
       [call(discoverExternalOcr, { visibleCanvases: ['canvasA', 'canvasB'], windowId }), {}],
@@ -335,6 +335,24 @@ describe('Reacting to configuration changes', () => {
         expect(effects.select).toBeUndefined();
         expect(effects.call).toBeUndefined();
       }));
+
+  it('should fetch texts for the visible canvases that were previously discovered but not yet requesteed',
+    () => expectSaga(
+      onConfigChange,
+      { id: windowId, payload: { textOverlay: { ...config, visible: true } } },
+    ).provide([
+      [select(getTextsForVisibleCanvases, { windowId }),
+        [
+          { sourceType: 'ocr', canvasId: 'canvasA', source: 'sourceA' },
+          { sourceType: 'ocr', canvasId: 'canvasB', source: 'sourceB' }]],
+      [select(getVisibleCanvases, { windowId }),
+        [
+          { id: 'canvasA', __jsonld: { width: 1000, height: 2000 } },
+          { id: 'canvasB', __jsonld: { width: 1500, height: 3000 } }]],
+    ])
+      .put(requestText('canvasA', 'sourceA', { width: 1000, height: 2000 }))
+      .put(requestText('canvasB', 'sourceB', { width: 1500, height: 3000 }))
+      .run());
 });
 
 describe('Fetching page colors', () => {

--- a/src/state/actions.js
+++ b/src/state/actions.js
@@ -13,10 +13,11 @@ export const PluginActionTypes = {
  * @param {String} targetId
  * @param {String} textUri
  */
-export function discoveredText(targetId, textUri) {
+export function discoveredText(targetId, textUri, sourceType = 'ocr') {
   return {
     targetId,
     textUri,
+    sourceType,
     type: PluginActionTypes.DISCOVERED_TEXT,
   };
 }

--- a/src/state/reducers.js
+++ b/src/state/reducers.js
@@ -10,6 +10,7 @@ export const textsReducer = (state = {}, action) => {
           ...state[action.targetId],
           canvasId: action.targetId,
           source: action.textUri,
+          sourceType: action.sourceType,
         },
       };
     case PluginActionTypes.REQUEST_TEXT:


### PR DESCRIPTION
In this case, any modifications to the plugin state on the initial canvas would not cause the text for the canvases to be fetched. This was because we only triggered *discovery* of texts, but not
*fetching* for those that were already discovered, but not fetched.