### PR TITLE
Always swallow pointerdown events if selection is enabled.

### DIFF
--- a/__tests__/components/PageTextDisplay.test.js
+++ b/__tests__/components/PageTextDisplay.test.js
@@ -136,21 +136,6 @@ describe('PageTextDisplay', () => {
     expect(topCallback).not.toHaveBeenCalled();
   });
 
-  it('should let pointerdown events through if touch screen is detected', () => {
-    const origTouchStart = global.window.ontouchstart;
-    global.window.ontouchstart = true;
-    const topCallback = jest.fn();
-    const { rerender, container } = renderPage({ selectable: false });
-    container.addEventListener('pointerdown', topCallback);
-    fireEvent.pointerDown(screen.getByText(svgTextMatcher('a firstWord on a line')));
-    expect(topCallback).toHaveBeenCalled();
-    topCallback.mockClear();
-    renderPage({ selectable: true }, rerender);
-    fireEvent.pointerDown(screen.getByText(svgTextMatcher('a firstWord on a line')));
-    global.window.ontouchstart = origTouchStart;
-    expect(topCallback).toHaveBeenCalled();
-  });
-
   it('should disable text selection if selection is disabled', () => {
     const { ref, container } = renderPage();
     expect(container.querySelectorAll('svg')[1]).toHaveStyle('user-select: text');

--- a/src/components/PageTextDisplay.js
+++ b/src/components/PageTextDisplay.js
@@ -7,16 +7,6 @@ function runningInGecko() {
   return navigator.userAgent.indexOf('Gecko/') >= 0;
 }
 
-/** Check if we're running on a touch screen */
-function runningOnTouchScreen() {
-  return (
-    'ontouchstart' in window
-    || (window.DocumentTouch && document instanceof window.DocumentTouch)
-    || navigator.maxTouchPoints > 0
-    || window.navigator.msMaxTouchPoints > 0
-  );
-}
-
 /** Page Text Display component that is optimized for fast panning/zooming
  *
  * NOTE: This component is doing stuff that is NOT RECOMMENDED GENERALLY, like
@@ -53,12 +43,10 @@ class PageTextDisplay extends React.Component {
   /** Swallow pointer events if selection is enabled */
   onPointerDown = (evt) => {
     const { selectable } = this.props;
-    // Let pointerdown events propagate on touch screens. Text selection is initiated by a long
-    // press gesture there, and disabling pointer down events make text selection very difficult,
-    // without having a lot of advantages.
-    if (!runningOnTouchScreen() && selectable) {
-      evt.stopPropagation();
+    if (!selectable) {
+      return;
     }
+    evt.stopPropagation();
   };
 
   /** Update the CSS transforms for the SVG container, i.e. scale and move the text overlay


### PR DESCRIPTION
Previously this was disabled for mobile devices, since we wanted for the user to be able to pan and zoom the OSD canvas despite selection being enabled. It turns out that this was very wonky across browsers, so we've enabled event-swallowing again.
This has the effect that, if selection is enabled, panning and zooming has to be initiated on parts of the canvas that are not covered by text.