### PR TITLE
Ensure that whitespace has a minimum width

### DIFF
--- a/__fixtures__/hocr.html
+++ b/__fixtures__/hocr.html
@@ -161,7 +161,7 @@
       <span class='ocrx_word' id='word_24_98' title='bbox 453 1085 531 1115; x_wconf 96'>von</span>
       <span class='ocrx_word' id='word_24_99' title='bbox 572 1075 637 1116; x_wconf 96'>der</span>
       <span class='ocrx_word' id='word_24_100' title='bbox 680 1074 862 1126; x_wconf 88'>kürzeſten</span>
-      <span class='ocrx_word' id='word_24_101' title='bbox 900 1072 1222 1125; x_wconf 92'>Heimwegslinie</span>
+      <span class='ocrx_word' id='word_24_101' title='bbox 862 1072 1222 1125; x_wconf 92'>Heimwegslinie</span>
       <span class='ocrx_word' id='word_24_102' title='bbox 1266 1070 1515 1123; x_wconf 96'>abgewichen.</span>
      </span>
      <span class='ocr_line' id='line_24_16' title="bbox 213 1138 1523 1195; baseline -0.003 -11; x_size 52; x_descenders 9; x_ascenders 13">

--- a/__tests__/lib/ocrFormats.test.js
+++ b/__tests__/lib/ocrFormats.test.js
@@ -118,6 +118,15 @@ describe('parsing hOCR', () => {
     console.warn = origWarn;
     expect(mockWarn).toHaveBeenCalled();
   });
+
+  it('should ensure that whitespace spans have a minimum width', () => {
+    const parsed = parseHocr(hocrMarkup, { height: 2389, width: 1600 });
+    expect(parsed.lines[14].spans[9]).toMatchObject({
+      text: ' ',
+      width: 0.0001,
+      x: 861.9999,
+    });
+  });
 });
 
 describe('parsing text from IIIF annotations', () => {

--- a/src/lib/ocrFormats.js
+++ b/src/lib/ocrFormats.js
@@ -100,16 +100,25 @@ export function parseHocr(hocrText, referenceSize) {
         // Calculate width of previous extra span
         const previousExtraSpan = spans.slice(-1).filter((s) => s.isExtra)?.[0];
         if (previousExtraSpan) {
-          previousExtraSpan.width = textSpans[0].x - previousExtraSpan.x;
+          let extraWidth = textSpans[0].x - previousExtraSpan.x;
+          if (extraWidth === 0) {
+            extraWidth = 0.0001;
+            previousExtraSpan.x -= extraWidth;
+          }
+          previousExtraSpan.width = extraWidth;
         }
-
         spans.push(...textSpans);
       }
 
       // Update with of extra span at end of line
       const endExtraSpan = spans.slice(-1).filter((s) => s.isExtra)?.[0];
       if (endExtraSpan) {
-        endExtraSpan.width = (line.x + line.width) - endExtraSpan.x;
+        let extraWidth = (line.x + line.width) - endExtraSpan.x;
+        if (extraWidth === 0) {
+          extraWidth = 0.0001;
+          endExtraSpan.x -= extraWidth;
+        }
+        endExtraSpan.width = extraWidth;
       }
 
       line.spans = spans;
@@ -211,12 +220,12 @@ export function parseAlto(altoText, imgSize) {
           .join('');
       }
 
-      const width = Number.parseInt(textNode.getAttribute('WIDTH'), 10) * scaleFactorX;
+      let width = Number.parseInt(textNode.getAttribute('WIDTH'), 10) * scaleFactorX;
       let height = Number.parseInt(textNode.getAttribute('HEIGHT'), 10) * scaleFactorY;
       if (Number.isNaN(height)) {
         height = line.height;
       }
-      const x = Number.parseInt(textNode.getAttribute('HPOS'), 10) * scaleFactorX;
+      let x = Number.parseInt(textNode.getAttribute('HPOS'), 10) * scaleFactorX;
       let y = Number.parseInt(textNode.getAttribute('VPOS'), 10) * scaleFactorY;
       if (Number.isNaN(y)) {
         y = line.y;
@@ -229,7 +238,13 @@ export function parseAlto(altoText, imgSize) {
         // between the previous word and this one.
         const previousExtraSpan = line.spans.slice(-1).filter((s) => s.isExtra)?.[0];
         if (previousExtraSpan) {
-          previousExtraSpan.width = x - previousExtraSpan.x;
+          let extraWidth = x - previousExtraSpan.x;
+          // Needed to force browsers to render the whitespace
+          if (extraWidth === 0) {
+            extraWidth = 0.0001;
+            previousExtraSpan.x -= extraWidth;
+          }
+          previousExtraSpan.width = extraWidth;
         }
 
         line.spans.push({
@@ -246,6 +261,11 @@ export function parseAlto(altoText, imgSize) {
         }
         lineEndsHyphenated = textNode.tagName === 'HYP';
       } else if (textNode.tagName === 'SP') {
+        // Needed to force browsers to render the whitespace
+        if (width === 0) {
+          width = 0.0001;
+          x -= width;
+        }
         line.spans.push({
           isExtra: false, x, y, width, height, text: ' ',
         });


### PR DESCRIPTION
This is a workaround for wonky OCR files that contain whitespace with an effective width of zero.
This would cause the selected text to not contain any whitespace, since the corresponding SVG span would have a width of zero, leading to it not rendering. We work arorund this by ensuring that whitespace has at least a width of `0.0001`, which is large enough for browsers to take it into account for text selection, but small enough not to be noticeable.