### PR TITLE
Hide settings bubble when no texts are available for visible canvases

### DIFF
--- a/src/state/selectors.js
+++ b/src/state/selectors.js
@@ -36,8 +36,12 @@ export const getTexts = (state) => miradorSlice(state).texts;
 /** Selector for text on all visible canvases */
 export const getTextsForVisibleCanvases = createSelector(
   [getVisibleCanvases, getTexts],
-  (canvases, texts) => {
-    if (!texts || !canvases) return null;
-    return canvases.map((c) => c.id).map((targetId) => texts[targetId]);
+  (canvases, allTexts) => {
+    if (!allTexts || !canvases) return [];
+    const texts = canvases.map((canvas) => allTexts[canvas.id]);
+    if (texts.every((t) => t === undefined)) {
+      return [];
+    }
+    return texts;
   }
 );


### PR DESCRIPTION
This used to work, but when we fixed the case where only one of the
visible canvases had a text, we introduced a regression.