### PR TITLE
Make sure default text/bg colors are WCAG-compliant

### DIFF
--- a/src/lib/color.js
+++ b/src/lib/color.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-param-reassign */
+
 /** Convert a rgb(...) or rgba(...) string to its hexadecimal representation. */
 export function toHexRgb(rgbColor) {
   if (!rgbColor || !rgbColor.startsWith('rgb')) {
@@ -14,6 +16,49 @@ export function toHexRgb(rgbColor) {
     .join('')}`;
 }
 
+/** Parse RGB(A) channels from a rgb(...) or rgba(...) string */
+function parseRgb(rgbColor) {
+  return rgbColor
+    .replace(/rgba?\((.+)\)/, '$1')
+    .split(',')
+    .map((x) => Number.parseInt(x.trim(), 10));
+}
+
+/** Calculate the luminance for a given RGB color.
+ *
+ * Algorithm and all constants taken from
+ * https://www.w3.org/TR/WCAG20-TECHS/G17.html#G17-procedure
+ */
+function luminance([r, g, b]) {
+  const colors = [r, g, b].map((v) => {
+    const vSrgb = v / 255;
+    if (vSrgb <= 0.03928) {
+      return vSrgb / 12.92;
+    }
+    return Math.pow((vSrgb + 0.055) / 1.055, 2.4);
+  });
+  return colors[0] * 0.2126 + colors[1] * 0.7152 + colors[2] * 0.0722;
+}
+
+/** Calculate the contrast between two RGB colors.
+ *
+ * Algorithm and all constants taken from
+ * https://www.w3.org/TR/WCAG20-TECHS/G17.html#G17-procedure
+ */
+function contrast(colorA, colorB) {
+  if (!Array.isArray(colorA)) {
+    colorA = parseRgb(colorA);
+  }
+  if (!Array.isArray(colorB)) {
+    colorB = parseRgb(colorB);
+  }
+  const luminanceA = luminance(colorA);
+  const luminanceB = luminance(colorB);
+  const brightest = Math.max(luminanceA, luminanceB);
+  const darkest = Math.min(luminanceA, luminanceB);
+  return (brightest + 0.05) / (darkest + 0.05);
+}
+
 /** Determine foreground and background color from text image. */
 export function getPageColors(imgData) {
   const colors = {};
@@ -26,15 +71,18 @@ export function getPageColors(imgData) {
     colors[rgb] = (colors[rgb] ?? 0) + 1;
   }
   // Really simple algorithm: The most frequent color is always going to be the text color,
-  // the next most frequent color is the background. This can and should probably be tweaked
-  // with some heuristics in the future (converting to HSL seems worthwhile), but it's good
-  // enough for now.
-  // FIXME: Testing with a cairo-backed canvas revelead that this approach relies a lot on
+  // the next most frequent color that has a contrast of at least 7:1 with the text color is
+  // the background. If no background color matches this criterioin, we use black or white,
+  // depending on the text color.
+  // This can and should probably be tweaked with some additional heuristics in the future
+  // (converting to HSL seems worthwhile), but it's good enough for now.
+  // FIXME: Testing with a cairo-backed canvas reveled that this approach relies a lot on
   //        the implementations in Firefox and Chrome, i.e. we got lucky. Needs more work
   //        to be more reliable and testable!
-  const [textColor, bgColor] = Object.entries(colors)
-    .sort((a, b) => b[1] - a[1])
-    .slice(0, 2)
-    .map(([k, v]) => k);
+  const sorted = Object.entries(colors).sort(([, freqA], [, freqB]) => freqB - freqA);
+  const textColor = sorted[0][0];
+  // Add fallback colors to list of candidate colors
+  sorted.push(['rgba(0, 0, 0)', 0], ['rgb(255, 255, 255)', 0]);
+  const bgColor = sorted.slice(1).find(([color]) => contrast(textColor, color) >= 7)[0];
   return { textColor, bgColor };
 }


### PR DESCRIPTION
We now try to pick a color for the background (from the available colors on the page) that fulfills the WCAG required minimum contrast ratio of 7:1.
If none can be found, we pick white or black as a fallback, depending on the text color.