### PR TITLE
hocr: Scale page size according to scale factor

### DIFF
--- a/src/lib/ocrFormats.js
+++ b/src/lib/ocrFormats.js
@@ -132,9 +132,9 @@ export function parseHocr(hocrText, referenceSize) {
     }
   }
   return {
-    height: pageSize[3],
+    height: pageSize[3] * scaleFactor,
     lines,
-    width: pageSize[2],
+    width: pageSize[2] * scaleFactor,
   };
 }
 


### PR DESCRIPTION
Previously we'd use the unscaled page sizes as parsed from the OCR, which would lead to cases where the text would be only partially visible.