### PR TITLE
Add support for customizing selection colors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,15 @@ changed through the UI, except for `enabled` and `fontFamily`) are:
   `#000000` (black)
 - `bgColor`: Set default text background color. RGB color string, defaults to
   `#ffffff` (white)
-- `fontFamily`: Font to use for rendering text. String or array of strings,
-  defaults to the theme's font
+
+The plugin also supports theming for a few things, these can be set under the
+`textOverlay` section for the light and/or dark theme (see
+[Mirador 3 Theming](https://github.com/ProjectMirador/mirador/wiki/M3-Theming-Mirador)
+on how to set these values):
+
+- `overlayFont`: Font(s) to use for rendering text. Any valid `font-family` CSS value
+- `selectionTextColor`: Color to use for rendering text when part of a selection. Any legal CSS color value.
+- `selectionBackgroundColor`: Color to use for text background when part of a selection. Any legal CSS color value.
 
 ## How it works
 The OCR or annotations boxes are rendered page-by-page and word-by-word into

--- a/src/components/PageTextDisplay.js
+++ b/src/components/PageTextDisplay.js
@@ -1,6 +1,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { fade } from '@material-ui/core/styles/colorManipulator';
+import withStyles from '@material-ui/core/styles/withStyles';
+
+/** Styles for the overlay SVG */
+const styles = (theme) => ({
+  textOverlay: {
+    'font-family': theme?.textOverlay?.overlayFont ?? 'sans-serif',
+    '& ::selection': {
+      fill: theme?.textOverlay?.selectionTextColor ?? 'rgba(255, 255, 255, 1)', // For Chrome
+      color: theme?.textOverlay?.selectionTextColor ?? 'rgba(255, 255, 255, 1)', // For Firefox
+      'background-color': theme?.textOverlay?.selectionBackgroundColor ?? 'rgba(0, 55, 255, 1)',
+    },
+  },
+});
 
 /** Check if we're running in Gecko */
 function runningInGecko() {
@@ -116,7 +129,7 @@ class PageTextDisplay extends React.Component {
       bgColor,
       useAutoColors,
       pageColors,
-      fontFamily,
+      classes,
     } = this.props;
 
     const containerStyle = {
@@ -145,7 +158,6 @@ class PageTextDisplay extends React.Component {
     const boxStyle = { fill: fade(bg, renderOpacity) };
     const textStyle = {
       fill: fade(fg, renderOpacity),
-      fontFamily,
     };
     const renderLines = lines.filter((l) => l.width > 0 && l.height > 0);
 
@@ -200,7 +212,7 @@ class PageTextDisplay extends React.Component {
             ))}
           </g>
         </svg>
-        <svg style={{ ...svgStyle, position: 'absolute' }}>
+        <svg style={{ ...svgStyle, position: 'absolute' }} className={classes.textOverlay}>
           <g ref={this.textContainerRef}>
             {renderLines.map((line) =>
               line.spans ? (
@@ -242,11 +254,11 @@ class PageTextDisplay extends React.Component {
 }
 
 PageTextDisplay.propTypes = {
+  classes: PropTypes.objectOf(PropTypes.string),
   selectable: PropTypes.bool.isRequired,
   visible: PropTypes.bool.isRequired,
   opacity: PropTypes.number.isRequired,
   textColor: PropTypes.string.isRequired,
-  fontFamily: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
   bgColor: PropTypes.string.isRequired,
   useAutoColors: PropTypes.bool.isRequired,
   width: PropTypes.number.isRequired,
@@ -258,10 +270,8 @@ PageTextDisplay.propTypes = {
   pageColors: PropTypes.object,
 };
 PageTextDisplay.defaultProps = {
+  classes: {},
   pageColors: undefined,
 };
-PageTextDisplay.defaultProps = {
-  fontFamily: undefined,
-};
 
-export default PageTextDisplay;
+export default withStyles(styles)(PageTextDisplay);


### PR DESCRIPTION
This introduces a new theme section `textOverlay` that allows customization of the text selection foreground and background color, as well as the general font-family to use for rendering text.
This improves text selection aesthetics for hidden text in WebKit-based browsers, which did not display the selected text before. The default colors are dark blue with a white foreground, due to the WCAG-compliant contrast ratio of 7:1.


<details>
<summary>Before</summary>

![image](https://user-images.githubusercontent.com/608610/115704546-c7921580-a36b-11eb-9d78-6b56b424bf33.png)
</details>

<details>
<summary>After</summary>

![image](https://user-images.githubusercontent.com/608610/115704438-aaf5dd80-a36b-11eb-9c68-73603b338ac9.png)
</details>