### PR TITLE
ci: allow to run ci manually

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
This PR adds `workflow_dispatch` so that CI can be started manually.