### PR TITLE
Don't crash on IIIF v3 annotation pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## Unreleased
 
-## [1.0.4](https://github.com/dbmdz/mirador-textoverlay/releases/tag/1.0.4) - 2026-06-25
-
 ### Fixed
 
 - Fixed crashes on IIIF v3 annotation pages without a `resources` array
 
-## [1.0.4](https://github.com/dbmdz/mirador-textoverlay/releases/tag/v1.0.4) - 2026-06-25
+## [1.0.4](https://github.com/dbmdz/mirador-textoverlay/releases/tag/1.0.4) - 2026-06-25
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ### Fixed
 
+- Fixed crashes on IIIF v3 annotation pages without a `resources` array
+
+## [1.0.4](https://github.com/dbmdz/mirador-textoverlay/releases/tag/v1.0.4) - 2026-06-25
+
+### Fixed
+
 - Fixed evaluation of fallback text color
 
 ## [1.0.3](https://github.com/dbmdz/mirador-textoverlay/releases/tag/1.0.3) - 2026-06-24

--- a/__tests__/state/sagas.test.js
+++ b/__tests__/state/sagas.test.js
@@ -263,6 +263,21 @@ describe('Fetching external annotation sources', () => {
         expect(effects.call).toBeUndefined();
         expect(effects.put).toBeUndefined();
       }));
+
+  it('should not do anything for IIIF v3 annotation pages without a resources array', () =>
+    expectSaga(fetchExternalAnnotationResources, {
+      annotationId,
+      annotationJson: {
+        items: [{ body: { value: 'a comment' }, motivation: 'commenting' }],
+        type: 'AnnotationPage',
+      },
+      targetId,
+    })
+      .run()
+      .then(({ effects }) => {
+        expect(effects.call).toBeUndefined();
+        expect(effects.put).toBeUndefined();
+      }));
 });
 
 describe('Processing text from regular annotations', () => {
@@ -284,6 +299,21 @@ describe('Processing text from regular annotations', () => {
       .put(receiveText('canvasA', 'annoList', 'annos', mockParse))
       .run();
   });
+
+  it('should not do anything for IIIF v3 annotation pages without a resources array', () =>
+    expectSaga(processTextsFromAnnotations, {
+      annotationId: 'annoPage',
+      annotationJson: {
+        items: [{ body: { value: 'a comment' }, motivation: 'commenting' }],
+        type: 'AnnotationPage',
+      },
+      targetId: 'canvasA',
+    })
+      .run()
+      .then(({ effects }) => {
+        expect(effects.call).toBeUndefined();
+        expect(effects.put).toBeUndefined();
+      }));
 });
 
 describe('Reacting to configuration changes', () => {

--- a/src/state/sagas.js
+++ b/src/state/sagas.js
@@ -123,7 +123,7 @@ export async function fetchAnnotationResource(url) {
 /** Saga for fetching external annotation resources */
 /** @returns {Generator} */
 export function* fetchExternalAnnotationResources({ targetId, annotationId, annotationJson }) {
-  if (!annotationJson.resources.some(hasExternalResource)) {
+  if (!annotationJson.resources?.some(hasExternalResource)) {
     return;
   }
   const resourceUris = uniq(
@@ -154,7 +154,9 @@ export function* fetchExternalAnnotationResources({ targetId, annotationId, anno
 export function* processTextsFromAnnotations({ targetId, annotationId, annotationJson }) {
   // Check if the annotation contains "content as text" resources that
   // we can extract text with coordinates from
-  const contentAsTextAnnos = annotationJson.resources.filter(
+  // IIIF v3 annotation pages keep their annotations in `items` instead of
+  // `resources`; those are not handled yet, so skip them instead of crashing.
+  const contentAsTextAnnos = (annotationJson.resources ?? []).filter(
     (anno) =>
       anno.motivation === 'supplementing' || // IIIF 3.0
       anno.resource['@type']?.toLowerCase() === 'cnt:contentastext' || // IIIF 2.0


### PR DESCRIPTION
## Purpose

The two `RECEIVE_ANNOTATION` sagas (`fetchExternalAnnotationResources` and `processTextsFromAnnotations`) read annotations from the IIIF v2 `AnnotationList` `resources` array. An IIIF v3 `AnnotationPage` keeps its annotations in `items` instead, so `resources` is `undefined` and both sagas throw a `TypeError` on every received v3 page.

This happens, for example, with annotations created via `mirador-annotation-editor` under Mirador 4, or with manifests that publish OCR text as v3 annotation pages (e.g. `https://iiif.wellcomecollection.org/presentation/v3/b18035723`). As soon as such an annotation page is received, the plugin crashes.

This is the crash half of the known v3 gap discussed in issue #186. The goal here is only to make the plugin ignore v3 pages gracefully instead of crashing.

## Approach

- Guard both sagas against a missing `resources` array (`resources?.some(...)` and `resources ?? []`), so annotation pages without it are skipped.
- Add saga tests covering v3 `AnnotationPage` payloads (annotations in `items`, no `resources`), asserting that neither saga dispatches any effects.
